### PR TITLE
Include status code & method in WAI instrumentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist/
 .cabal-sandbox/
 cabal.sandbox.config
 cabal.config
+/.stack-work

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,6 +4,4 @@ packages:
 - wai-middleware-prometheus/
 - example/
 - prometheus-client/
-extra-deps:
-- atomic-primops-0.8
-resolver: lts-2.15
+resolver: lts-7.2

--- a/wai-middleware-prometheus/src/Network/Wai/Middleware/Prometheus.hs
+++ b/wai-middleware-prometheus/src/Network/Wai/Middleware/Prometheus.hs
@@ -88,14 +88,8 @@ prometheus :: PrometheusSettings -> Wai.Middleware
 prometheus PrometheusSettings{..} app req respond =
     if     Wai.requestMethod req == HTTP.methodGet
         && Wai.pathInfo req == prometheusEndPoint
-    then measure measureMetrics "prometheus" $ respondWithMetrics respond
-    else measure measureApp "app" $ app req respond
-    where
-        measureMetrics = prometheusInstrumentPrometheus
-        measureApp = prometheusInstrumentApp
-        measure shouldInstrument handler io
-            | shouldInstrument = observeMicroSeconds handler io
-            | otherwise        = io
+    then instrumentApp "prometheus" (const respondWithMetrics) req respond
+    else instrumentApp "app" app req respond
 
 
 -- | WAI Application that serves the Prometheus metrics page regardless of

--- a/wai-middleware-prometheus/src/Network/Wai/Middleware/Prometheus.hs
+++ b/wai-middleware-prometheus/src/Network/Wai/Middleware/Prometheus.hs
@@ -86,7 +86,7 @@ instrumentIO label io = do
     result <- io
     end    <- getCurrentTime
     observeMicroSeconds label Nothing Nothing start end
-    pure result
+    return result
 
 observeMicroSeconds :: String -> Maybe String -> Maybe String -> UTCTime -> UTCTime -> IO ()
 observeMicroSeconds handler method status start end = do


### PR DESCRIPTION
I think a good default for instrumentation is to include status code and method. This PR changes the WAI instrumentation to do that.

The cost of this is that `instrumentIO` has to go, since we can't get method or status code information about arbitrary IO actions.

I won't be too hurt if you don't think this is a good idea. There are a couple of `XXX` comments which I can file as bugs (or just fix) if you think are good ideas.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fimad/prometheus-haskell/4)
<!-- Reviewable:end -->
