### PR TITLE
Export metrics page as Application

### DIFF
--- a/wai-middleware-prometheus/src/Network/Wai/Middleware/Prometheus.hs
+++ b/wai-middleware-prometheus/src/Network/Wai/Middleware/Prometheus.hs
@@ -8,6 +8,7 @@ module Network.Wai.Middleware.Prometheus (
 ,   Default.def
 ,   instrumentApp
 ,   instrumentIO
+,   metricsApp
 ) where
 
 import Data.Time.Clock (diffUTCTime, getCurrentTime)
@@ -95,6 +96,12 @@ prometheus PrometheusSettings{..} app req respond =
         measure shouldInstrument handler io
             | shouldInstrument = observeMicroSeconds handler io
             | otherwise        = io
+
+
+-- | WAI Application that serves the Prometheus metrics page regardless of
+-- what the request is.
+metricsApp :: Wai.Application
+metricsApp = const respondWithMetrics
 
 respondWithMetrics :: (Wai.Response -> IO Wai.ResponseReceived)
                    -> IO Wai.ResponseReceived


### PR DESCRIPTION
If you don't want to use the default instrumentation, then you still
need some way of actually exposing /metrics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fimad/prometheus-haskell/6)
<!-- Reviewable:end -->
