### PR TITLE
Use Counters for GHC metrics

### DIFF
--- a/prometheus-metrics-ghc/src/Prometheus/Metric/GHC.hs
+++ b/prometheus-metrics-ghc/src/Prometheus/Metric/GHC.hs
@@ -31,93 +31,112 @@ ghcCollectors = [
         showCollector
             "ghc_sparks"
             "The number of sparks in the local spark pool."
+            GaugeType
             numSparks
     ,   showCollector
             "ghc_capabilities"
             "The number of threads that can run truly simultaneously."
+            GaugeType
             getNumCapabilities
     ,   statsCollector
             "ghc_bytes_allocated"
             "Total number of bytes allocated."
+            CounterType
             bytesAllocated
     ,   statsCollector
             "ghc_num_gcs"
             "The number of garbage collections performed."
+            CounterType
             numGcs
     ,   statsCollector
             "ghc_max_bytes_used"
             "The maximum number of live bytes seen so far."
+            GaugeType
             maxBytesUsed
     ,   statsCollector
             "ghc_cumulative_bytes_used"
             "The cumulative total bytes used."
+            CounterType
             cumulativeBytesUsed
     ,   statsCollector
             "ghc_bytes_copied"
             "The number of bytes copied during garbage collection."
+            CounterType
             bytesCopied
     ,   statsCollector
             "ghc_current_bytes_used"
             "The number of current live bytes."
+            GaugeType
             currentBytesUsed
     ,   statsCollector
             "ghc_current_bytes_slop"
             "The current number of bytes lost to slop."
+            GaugeType
             currentBytesSlop
     ,   statsCollector
             "ghc_max_bytes_slop"
             "The maximum number of bytes lost to slop so far."
+            GaugeType
             maxBytesSlop
     ,   statsCollector
             "ghc_peak_megabytes_allocated"
             "The maximum number of megabytes allocated."
+            GaugeType
             peakMegabytesAllocated
     ,   statsCollector
             "ghc_mutator_cpu_seconds"
             "The CPU time spent running mutator threads."
+            CounterType
             mutatorCpuSeconds
     ,   statsCollector
             "ghc_mutator_wall_seconds"
             "The wall clock time spent running mutator threads."
+            CounterType
             mutatorCpuSeconds
     ,   statsCollector
             "ghc_gc_cpu_seconds"
             "The CPU time spent running GC."
+            CounterType
             gcCpuSeconds
     ,   statsCollector
             "ghc_gc_wall_seconds"
             "The wall clock time spent running GC."
+            CounterType
             gcWallSeconds
     ,   statsCollector
             "ghc_cpu_seconds"
             "Total CPU time elapsed since program start."
+            CounterType
             cpuSeconds
     ,   statsCollector
             "ghc_wall_seconds"
             "Total wall clock time elapsed since start."
+            CounterType
             wallSeconds
     ,   statsCollector
             "ghc_parallel_total_bytes_copied"
             ("Number of bytes copied during GC, minus space held by mutable "
                 ++ "lists held by the capabilities.")
+            CounterType
             parTotBytesCopied
     ,   statsCollector
             "ghc_parallel_max_bytes_copied"
             ("Sum of number of bytes copied each GC by the most active GC "
                 ++ "thread each GC.")
+            CounterType
             parMaxBytesCopied
     ]
 
 statsCollector :: Show a
-               => String -> String -> (GCStats -> a) -> IO [SampleGroup]
-statsCollector name help stat = do
+               => String -> String -> SampleType -> (GCStats -> a) -> IO [SampleGroup]
+statsCollector name help sampleType stat = do
     statsEnabled <- getGCStatsEnabled
     if statsEnabled
-        then showCollector name help (stat <$> getGCStats)
+        then showCollector name help sampleType (stat <$> getGCStats)
         else return []
 
-showCollector :: Show a => String -> String -> IO a -> IO [SampleGroup]
-showCollector name help ioInt = do
+showCollector :: Show a => String -> String -> SampleType -> IO a -> IO [SampleGroup]
+showCollector name help sampleType ioInt = do
     value <- ioInt
     let info = Info name help
     let valueBS = BS.fromString $ show value

--- a/prometheus-metrics-ghc/src/Prometheus/Metric/GHC.hs
+++ b/prometheus-metrics-ghc/src/Prometheus/Metric/GHC.hs
@@ -39,7 +39,7 @@ ghcCollectors = [
             GaugeType
             getNumCapabilities
     ,   statsCollector
-            "ghc_bytes_allocated"
+            "ghc_allocated_bytes_total"
             "Total number of bytes allocated."
             CounterType
             bytesAllocated
@@ -49,78 +49,78 @@ ghcCollectors = [
             CounterType
             numGcs
     ,   statsCollector
-            "ghc_max_bytes_used"
+            "ghc_max_used_bytes"
             "The maximum number of live bytes seen so far."
             GaugeType
             maxBytesUsed
     ,   statsCollector
-            "ghc_cumulative_bytes_used"
+            "ghc_cumulative_used_bytes_total"
             "The cumulative total bytes used."
             CounterType
             cumulativeBytesUsed
     ,   statsCollector
-            "ghc_bytes_copied"
+            "ghc_copied_bytes_total"
             "The number of bytes copied during garbage collection."
             CounterType
             bytesCopied
     ,   statsCollector
-            "ghc_current_bytes_used"
+            "ghc_current_used_bytes"
             "The number of current live bytes."
             GaugeType
             currentBytesUsed
     ,   statsCollector
-            "ghc_current_bytes_slop"
+            "ghc_current_slop_bytes"
             "The current number of bytes lost to slop."
             GaugeType
             currentBytesSlop
     ,   statsCollector
-            "ghc_max_bytes_slop"
+            "ghc_max_slop_bytes"
             "The maximum number of bytes lost to slop so far."
             GaugeType
             maxBytesSlop
     ,   statsCollector
-            "ghc_peak_megabytes_allocated"
+            "ghc_peak_allocated_megabytes" -- XXX: export as bytes?
             "The maximum number of megabytes allocated."
             GaugeType
             peakMegabytesAllocated
     ,   statsCollector
-            "ghc_mutator_cpu_seconds"
+            "ghc_mutator_cpu_seconds_total"
             "The CPU time spent running mutator threads."
             CounterType
             mutatorCpuSeconds
     ,   statsCollector
-            "ghc_mutator_wall_seconds"
+            "ghc_mutator_wall_seconds_total"
             "The wall clock time spent running mutator threads."
             CounterType
             mutatorCpuSeconds
     ,   statsCollector
-            "ghc_gc_cpu_seconds"
+            "ghc_gc_cpu_seconds_total"
             "The CPU time spent running GC."
             CounterType
             gcCpuSeconds
     ,   statsCollector
-            "ghc_gc_wall_seconds"
+            "ghc_gc_wall_seconds_total"
             "The wall clock time spent running GC."
             CounterType
             gcWallSeconds
     ,   statsCollector
-            "ghc_cpu_seconds"
+            "ghc_cpu_seconds_total"
             "Total CPU time elapsed since program start."
             CounterType
             cpuSeconds
     ,   statsCollector
-            "ghc_wall_seconds"
+            "ghc_wall_seconds_total"
             "Total wall clock time elapsed since start."
             CounterType
             wallSeconds
     ,   statsCollector
-            "ghc_parallel_total_bytes_copied"
+            "ghc_parallel_copied_bytes_total"
             ("Number of bytes copied during GC, minus space held by mutable "
                 ++ "lists held by the capabilities.")
             CounterType
             parTotBytesCopied
     ,   statsCollector
-            "ghc_parallel_max_bytes_copied"
+            "ghc_parallel_max_copied_bytes_total"
             ("Sum of number of bytes copied each GC by the most active GC "
                 ++ "thread each GC.")
             CounterType


### PR DESCRIPTION
Something of a follow-up to https://github.com/fimad/prometheus-haskell/pull/12, but not strictly dependent on it.

Many of the GHC stats are strictly accumulating counts. Exporting these as Counters more clearly communicates their behaviour.

After doing this, it seemed to make sense to update the names of the metrics to match the [best practices guide](https://prometheus.io/docs/practices/naming/). This is a potentially disruptive change to users of the library, so I guess it needs an appropriate version bump & changelog entry too.