### PR TITLE
Use Histogram, not Summary, in WAI

### DIFF
--- a/prometheus-client/prometheus-client.cabal
+++ b/prometheus-client/prometheus-client.cabal
@@ -38,11 +38,11 @@ library
       atomic-primops     >=0.4
     , base               >=4.7 && <5
     , bytestring         >=0.9
+    , clock
     , containers
     , mtl                >=2
     , stm                >=2.3
     , transformers
-    , time
     , utf8-string
   ghc-options: -Wall
 
@@ -68,11 +68,11 @@ test-suite spec
     , base               >=4.7 && <5
     , bytestring
     , containers
+    , clock
     , hspec
     , mtl
     , random-shuffle
     , stm
-    , time
     , transformers
     , utf8-string
   ghc-options: -Wall

--- a/prometheus-client/src/Prometheus/Metric/Counter.hs
+++ b/prometheus-client/src/Prometheus/Metric/Counter.hs
@@ -10,10 +10,10 @@ module Prometheus.Metric.Counter (
 
 import Prometheus.Info
 import Prometheus.Metric
+import Prometheus.Metric.Observer (timeAction)
 import Prometheus.MonadMonitor
 
 import Control.Monad (unless)
-import Data.Time.Clock (diffUTCTime, getCurrentTime)
 import qualified Data.Atomics as Atomics
 import qualified Data.ByteString.UTF8 as BS
 import qualified Data.IORef as IORef
@@ -60,10 +60,8 @@ unsafeAddCounter x c = do
 -- | Add the duration of an IO action (in seconds) to a counter.
 addDurationToCounter :: IO a -> Metric Counter -> IO a
 addDurationToCounter io metric = do
-    start  <- getCurrentTime
-    result <- io
-    end    <- getCurrentTime
-    addCounter (fromRational $ toRational $ end `diffUTCTime` start) metric
+    (result, duration) <- timeAction io
+    _ <- addCounter duration metric
     return result
 
 -- | Retrieves the current value of a counter metric.

--- a/prometheus-client/src/Prometheus/Metric/Gauge.hs
+++ b/prometheus-client/src/Prometheus/Metric/Gauge.hs
@@ -12,9 +12,9 @@ module Prometheus.Metric.Gauge (
 
 import Prometheus.Info
 import Prometheus.Metric
+import Prometheus.Metric.Observer (timeAction)
 import Prometheus.MonadMonitor
 
-import Data.Time.Clock (diffUTCTime, getCurrentTime)
 import qualified Data.Atomics as Atomics
 import qualified Data.ByteString.UTF8 as BS
 import qualified Data.IORef as IORef
@@ -68,10 +68,8 @@ getGauge (Metric {handle = MkGauge ioref}) = IORef.readIORef ioref
 -- | Sets a gauge metric to the duration in seconds of an IO action.
 setGaugeToDuration :: IO a -> Metric Gauge -> IO a
 setGaugeToDuration io metric = do
-    start  <- getCurrentTime
-    result <- io
-    end    <- getCurrentTime
-    setGauge (fromRational $ toRational $ end `diffUTCTime` start) metric
+    (result, duration) <- timeAction io
+    setGauge duration metric
     return result
 
 collectGauge :: Info -> IORef.IORef Double -> IO [SampleGroup]

--- a/wai-middleware-prometheus/src/Network/Wai/Middleware/Prometheus.hs
+++ b/wai-middleware-prometheus/src/Network/Wai/Middleware/Prometheus.hs
@@ -49,9 +49,9 @@ instance Default.Default PrometheusSettings where
 {-# NOINLINE requestLatency #-}
 -- XXX: https://prometheus.io/docs/practices/naming/ says this should be
 -- _seconds, not _microseconds.
-requestLatency :: Prom.Metric (Prom.Vector Prom.Label3 Prom.Summary)
+requestLatency :: Prom.Metric (Prom.Vector Prom.Label3 Prom.Histogram)
 requestLatency = Prom.unsafeRegisterIO $ Prom.vector ("handler", "method", "status_code")
-                                       $ Prom.summary info Prom.defaultQuantiles
+                                       $ Prom.histogram info Prom.defaultBuckets
     where info = Prom.Info "http_request_duration_seconds"
                            "The HTTP request latencies in seconds."
 

--- a/wai-middleware-prometheus/wai-middleware-prometheus.cabal
+++ b/wai-middleware-prometheus/wai-middleware-prometheus.cabal
@@ -26,11 +26,11 @@ library
   build-depends:
       base               >=4.7 && <5
     , bytestring         >=0.9
+    , clock
     , data-default
     , http-types
     , prometheus-client
     , text               >=0.11
-    , time
     , wai                >=3.0
   ghc-options: -Wall
 


### PR DESCRIPTION
Tiny follow-on from #17, but logically independent. Probably shouldn't be reviewed until after #16 and #17.

Uses Histograms, not Summary, in WAI, which allows metrics gathered from multiple processes to be aggregated meaningfully.

This is kind of a breaking change, as queries that work on summaries don't work on histograms. I suggest combining this change with #17 in a release, so that at least at the PromQL level, we change a name at the same time as changing the semantics.

Full discussion of summaries vs histograms at https://prometheus.io/docs/practices/histograms/