### PR TITLE
Allow user-defined labelling functions

### DIFF
--- a/prometheus-client/src/Prometheus/Metric/Histogram.hs
+++ b/prometheus-client/src/Prometheus/Metric/Histogram.hs
@@ -1,3 +1,4 @@
+{-# language BangPatterns #-}
 {-# language OverloadedStrings #-}
 
 module Prometheus.Metric.Histogram (
@@ -75,7 +76,7 @@ instance Observer Histogram where
 -- | Transform the contents of a histogram.
 withHistogram :: MonadMonitor m
               => Histogram -> (BucketCounts -> BucketCounts) -> m ()
-withHistogram (MkHistogram bucketCounts) f =
+withHistogram (MkHistogram !bucketCounts) f =
   doIO $ STM.atomically $ STM.modifyTVar' bucketCounts f
 
 -- | Retries a map of upper bounds to counts of values observed that are

--- a/prometheus-client/src/Prometheus/Metric/Summary.hs
+++ b/prometheus-client/src/Prometheus/Metric/Summary.hs
@@ -1,3 +1,4 @@
+{-# language BangPatterns #-}
 {-# language OverloadedStrings #-}
 
 module Prometheus.Metric.Summary (
@@ -49,7 +50,7 @@ summary info quantiles = Metric $ do
 
 withSummary :: MonadMonitor m
             => Summary -> (Estimator -> Estimator) -> m ()
-withSummary (MkSummary valueTVar) f =
+withSummary (MkSummary !valueTVar) f =
     doIO $ STM.atomically $ do
         STM.modifyTVar' valueTVar compress
         STM.modifyTVar' valueTVar f

--- a/prometheus-client/tests/Prometheus/Metric/HistogramSpec.hs
+++ b/prometheus-client/tests/Prometheus/Metric/HistogramSpec.hs
@@ -1,8 +1,13 @@
+{-# language OverloadedStrings #-}
+
 module Prometheus.Metric.HistogramSpec (
     spec
 ) where
 
 import Prometheus.Metric.Histogram
+import Prometheus.Metric.Observer
+import Prometheus.Registry
+import Prometheus.Info
 
 import qualified Data.Map.Strict as Map
 import Test.Hspec
@@ -11,6 +16,17 @@ import Test.QuickCheck
 spec :: Spec
 spec = describe "Prometheus.Metric.Histogram" $ do
     context "Maintains invariants" invariantTests
+    context "Laziness tests" observeToUnsafe
+
+{-# NOINLINE testMetric #-}
+testMetric :: Histogram
+testMetric = do
+  unsafeRegister $ histogram (Info "test_histogram" "")  defaultBuckets
+  
+observeToUnsafe :: Spec
+observeToUnsafe =
+  it "Is able to observe to a top-level 'unsafeRegister' metric" $ do
+    observe testMetric 1 `shouldReturn` ()
 
 --------------------------------------------------------------------------------
 -- QuickCheck tests

--- a/prometheus-client/tests/Prometheus/Metric/SummarySpec.hs
+++ b/prometheus-client/tests/Prometheus/Metric/SummarySpec.hs
@@ -22,6 +22,7 @@ import Test.QuickCheck
 
 spec :: Spec
 spec = describe "Prometheus.Metric.Summary" $ do
+    observeToUnsafe 
     let windowSize = 10000
     it "computes quantiles correctly for [0,10000) in order" $ do
         m <- register $ summary (Info "name" "help") quantiles
@@ -51,6 +52,17 @@ spec = describe "Prometheus.Metric.Summary" $ do
             m <- register $ summary (Info "name" "help") quantiles
             mapM_ (m `observe`) observations
             checkQuantiles m windowSize =<< getQuantiles quantiles m
+
+{-# NOINLINE testMetric #-}
+testMetric :: Summary
+testMetric = do
+  unsafeRegister $ summary (Info "test_histogram" "") quantiles
+  
+observeToUnsafe :: Spec
+observeToUnsafe =
+  it "Is able to observe to a top-level 'unsafeRegister' metric" $ do
+    observe testMetric 1 `shouldReturn` ()
+
 
 badObservations1 :: [Double]
 badObservations1 = [38.0, 17.0, 5.0, 36.0, 85.0, 63.0, 3.0, 24.0, 0.0, 12.0,

--- a/wai-middleware-prometheus/wai-middleware-prometheus.cabal
+++ b/wai-middleware-prometheus/wai-middleware-prometheus.cabal
@@ -1,5 +1,5 @@
 name:                wai-middleware-prometheus
-version:             0.3.0
+version:             0.3.1
 synopsis:
     WAI middlware for exposing http://prometheus.io metrics.
 description:

--- a/wai-middleware-prometheus/wai-middleware-prometheus.cabal
+++ b/wai-middleware-prometheus/wai-middleware-prometheus.cabal
@@ -1,5 +1,5 @@
 name:                wai-middleware-prometheus
-version:             0.3.1
+version:             0.3.0
 synopsis:
     WAI middlware for exposing http://prometheus.io metrics.
 description:


### PR DESCRIPTION
This patch provides the ability for users to write their own labelling functions through `instrumentWithLabels`, and updates `instrumentApp` — as it is now a special case of the former.

This provides necessary machinery for further packages to build upon, such as Yesod auto-generated `(Request -> Text)` labelling functions based on routes.