### PR TITLE
Help solving issues with `ResponseRaw` end-points in promth. middleware.

### DIFF
--- a/wai-middleware-prometheus/src/Network/Wai/Middleware/Prometheus.hs
+++ b/wai-middleware-prometheus/src/Network/Wai/Middleware/Prometheus.hs
@@ -11,6 +11,7 @@ module Network.Wai.Middleware.Prometheus
   , instrumentApp
   , instrumentIO
   , metricsApp
+  , observeSeconds  -- for allowing to re-implement instrumentHandlerValue; better patch coming up!
   ) where
 
 import qualified Data.Default as Default


### PR DESCRIPTION
The issue is explained [here](https://github.com/wireapp/wire-server/pull/750#issuecomment-490894649).  We fixed it in [wire](https://github.com/wireapp/wire-server/pull/751), [twice](https://github.com/wireapp/wire-server/pull/754).  Other people have fixed this elsewhere before, like [here](https://github.com/yesodweb/wai/issues/265).

There are a few different ways of solving this.  For now I only need this one export.  I hope to write down a solution that works for all users of `wai-middleware-prometheus`.