### PR TITLE
prometheus-proc: Use Data.Text.readFile

### DIFF
--- a/prometheus-proc/prometheus-proc.cabal
+++ b/prometheus-proc/prometheus-proc.cabal
@@ -22,7 +22,7 @@ library
                      , filepath >=1.4 && <1.5
                      , prometheus-client >= 1.0.0 && < 1.1
                      , regex-applicative >=0.3 && <0.4
-                     , text >= 0.1 && < 1.3
+                     , text >= 0.7 && < 1.3
                      , unix >=2.7 && <2.8
                      , unix-memory >=0.1 && <0.2
   hs-source-dirs:      src

--- a/prometheus-proc/src/Prometheus/Metric/Proc.hs
+++ b/prometheus-proc/src/Prometheus/Metric/Proc.hs
@@ -15,8 +15,10 @@ import Data.Char ( isSpace )
 import Data.Int ( Int64 )
 import Data.Maybe ( catMaybes )
 import Data.String ( fromString )
-import Data.Text ( Text )
+import Data.Text ( Text, unpack )
+import Data.Text.IO ( readFile )
 import Foreign.C
+import Prelude hiding ( readFile )
 import Prometheus
 import System.Directory ( listDirectory )
 import System.FilePath
@@ -66,7 +68,7 @@ collect = do
     getProcessID
 
   mprocStat <-
-      RE.match parseProcStat <$> readFile ( procPidDir pid </> "stat" )
+      RE.match parseProcStat . unpack <$> readFile ( procPidDir pid </> "stat" )
 
   processOpenFds <-
     collectProcessOpenFds pid
@@ -163,7 +165,7 @@ value.
 {-# NOINLINE mbtime #-}
 mbtime :: Maybe Int64
 mbtime = unsafePerformIO $ do
-  fmap ( \( _, a, _ ) -> a ) . RE.findFirstInfix ( "btime " *> RE.decimal )
+  fmap ( \( _, a, _ ) -> a ) . RE.findFirstInfix ( "btime " *> RE.decimal ) . unpack
     <$> readFile "/proc/stat"
 
 


### PR DESCRIPTION
Prelude.readFile uses lazy IO which makes resource usage harder to
reason about.