### PR TITLE
Added possability to label GHC metrics

### DIFF
--- a/prometheus-metrics-ghc/src/Prometheus/Metric/GHC.hs
+++ b/prometheus-metrics-ghc/src/Prometheus/Metric/GHC.hs
@@ -41,12 +41,14 @@ ghcMetricsWithLabels labels = Metric (return (GHCMetrics, concat <$> mapM ($ lab
 #if __GLASGOW_HASKELL__ < 804
 ghcCollectors :: [LabelPairs -> IO [SampleGroup]]
 ghcCollectors = [
-        showCollector
+        \labels -> showCollector
+            labels
             "ghc_sparks"
             "The number of sparks in the local spark pool."
             GaugeType
             numSparks
-    ,   showCollector
+    ,   \labels -> showCollector
+            labels
             "ghc_capabilities"
             "The number of threads that can run truly simultaneously."
             GaugeType

--- a/prometheus-metrics-ghc/src/Prometheus/Metric/GHC.hs
+++ b/prometheus-metrics-ghc/src/Prometheus/Metric/GHC.hs
@@ -13,18 +13,14 @@
 module Prometheus.Metric.GHC (
     GHCMetrics
 ,   ghcMetrics
+,   ghcMetricsWithLabels
 ) where
 
 import Control.Applicative ((<$>))
 import qualified Data.ByteString.UTF8 as BS
 import Data.Text (Text)
 import Data.Fixed (Fixed, E9)
-#if __GLASGOW_HASKELL__ < 804
-import GHC.Conc (numSparks, getNumCapabilities)
-import GHC.Stats (GCStats(..), getGCStatsEnabled, getGCStats)
-#else
 import GHC.Stats (RTSStats(..), GCDetails(..), getRTSStatsEnabled, getRTSStats)
-#endif
 import qualified GHC.Stats as Stats
 import Prometheus
 
@@ -32,111 +28,12 @@ import Prometheus
 data GHCMetrics = GHCMetrics
 
 ghcMetrics :: Metric GHCMetrics
-ghcMetrics = Metric (return (GHCMetrics, concat <$> sequence ghcCollectors))
+ghcMetrics = ghcMetricsWithLabels []
 
-#if __GLASGOW_HASKELL__ < 804
-ghcCollectors :: [IO [SampleGroup]]
-ghcCollectors = [
-        showCollector
-            "ghc_sparks"
-            "The number of sparks in the local spark pool."
-            GaugeType
-            numSparks
-    ,   showCollector
-            "ghc_capabilities"
-            "The number of threads that can run truly simultaneously."
-            GaugeType
-            getNumCapabilities
-    ,   statsCollector
-            "ghc_allocated_bytes_total"
-            "Total number of bytes allocated."
-            CounterType
-            bytesAllocated
-    ,   statsCollector
-            "ghc_num_gcs"
-            "The number of garbage collections performed."
-            CounterType
-            numGcs
-    ,   statsCollector
-            "ghc_max_used_bytes"
-            "The maximum number of live bytes seen so far."
-            GaugeType
-            maxBytesUsed
-    ,   statsCollector
-            "ghc_cumulative_used_bytes_total"
-            "The cumulative total bytes used."
-            CounterType
-            cumulativeBytesUsed
-    ,   statsCollector
-            "ghc_copied_bytes_total"
-            "The number of bytes copied during garbage collection."
-            CounterType
-            bytesCopied
-    ,   statsCollector
-            "ghc_current_used_bytes"
-            "The number of current live bytes."
-            GaugeType
-            currentBytesUsed
-    ,   statsCollector
-            "ghc_current_slop_bytes"
-            "The current number of bytes lost to slop."
-            GaugeType
-            currentBytesSlop
-    ,   statsCollector
-            "ghc_max_slop_bytes"
-            "The maximum number of bytes lost to slop so far."
-            GaugeType
-            maxBytesSlop
-    ,   statsCollector
-            "ghc_peak_allocated_megabytes" -- XXX: export as bytes?
-            "The maximum number of megabytes allocated."
-            GaugeType
-            peakMegabytesAllocated
-    ,   statsCollector
-            "ghc_mutator_cpu_seconds_total"
-            "The CPU time spent running mutator threads."
-            CounterType
-            mutatorCpuSeconds
-    ,   statsCollector
-            "ghc_mutator_wall_seconds_total"
-            "The wall clock time spent running mutator threads."
-            CounterType
-            mutatorCpuSeconds
-    ,   statsCollector
-            "ghc_gc_cpu_seconds_total"
-            "The CPU time spent running GC."
-            CounterType
-            gcCpuSeconds
-    ,   statsCollector
-            "ghc_gc_wall_seconds_total"
-            "The wall clock time spent running GC."
-            CounterType
-            gcWallSeconds
-    ,   statsCollector
-            "ghc_cpu_seconds_total"
-            "Total CPU time elapsed since program start."
-            CounterType
-            cpuSeconds
-    ,   statsCollector
-            "ghc_wall_seconds_total"
-            "Total wall clock time elapsed since start."
-            CounterType
-            wallSeconds
-    ,   statsCollector
-            "ghc_parallel_copied_bytes_total"
-            "Number of bytes copied during GC, minus space held by mutable lists held by the capabilities."
-            CounterType
-            parTotBytesCopied
-    ,   statsCollector
-            "ghc_parallel_max_copied_bytes_total"
-            "Sum of number of bytes copied each GC by the most active GC thread each GC."
-            CounterType
-            parMaxBytesCopied
-    ]
+ghcMetricsWithLabels :: LabelPairs -> Metric GHCMetrics
+ghcMetricsWithLabels labels = Metric (return (GHCMetrics, concat <$> mapM ($ labels) ghcCollectors))
 
-#else
-
-ghcCollectors :: [IO [SampleGroup]]
+ghcCollectors :: [LabelPairs -> IO [SampleGroup]]
 ghcCollectors = [
       statsCollector
             "ghc_gcs_total"
@@ -302,29 +199,18 @@ ghcCollectors = [
 -- | Convert from 'RtsTime' (nanoseconds) to seconds with nanosecond precision.
 rtsTimeToSeconds :: Stats.RtsTime -> Fixed E9
 rtsTimeToSeconds = (/ 1e9) . fromIntegral
-#endif
 
-#if __GLASGOW_HASKELL__ < 804
 statsCollector :: Show a
-               => Text -> Text -> SampleType -> (GCStats -> a) -> IO [SampleGroup]
-statsCollector name help sampleType stat = do
-    statsEnabled <- getGCStatsEnabled
-    if statsEnabled
-        then showCollector name help sampleType (stat <$> getGCStats)
-        else return []
-#else
-statsCollector :: Show a
-               => Text -> Text -> SampleType -> (RTSStats -> a) -> IO [SampleGroup]
-statsCollector name help sampleType stat = do
+               => Text -> Text -> SampleType -> (RTSStats -> a) -> LabelPairs -> IO [SampleGroup]
+statsCollector name help sampleType stat labels = do
     statsEnabled <- getRTSStatsEnabled
     if statsEnabled
-        then showCollector name help sampleType (stat <$> getRTSStats)
+        then showCollector labels name help sampleType (stat <$> getRTSStats)
         else return []
-#endif
 
-showCollector :: Show a => Text -> Text -> SampleType -> IO a -> IO [SampleGroup]
-showCollector name help sampleType ioInt = do
+showCollector :: Show a => LabelPairs -> Text -> Text -> SampleType -> IO a -> IO [SampleGroup]
+showCollector labels name help sampleType ioInt = do
     value <- ioInt
     let info = Info name help
     let valueBS = BS.fromString $ show value
-    return [SampleGroup info sampleType [Sample name [] valueBS]]
+    return [SampleGroup info sampleType [Sample name labels valueBS]]


### PR DESCRIPTION
Quick hack to include Prometheus labels in GHC metrics - solves https://github.com/fimad/prometheus-haskell/issues/52.
Please note that this was just a 'hack' to add labels - but it maybe it could be used as a starting point for this feature.