### PR TITLE
strictify histCountsPerBucket

### DIFF
--- a/prometheus-client/src/Prometheus/Metric/Histogram.hs
+++ b/prometheus-client/src/Prometheus/Metric/Histogram.hs
@@ -59,7 +59,7 @@ data BucketCounts = BucketCounts {
     -- | Counts for each bucket. The key is the upper-bound,
     -- value is the number of observations less-than-or-equal-to
     -- that upper bound, but greater than the next lowest upper bound.
-,   histCountsPerBucket :: Map.Map Bucket Int
+,   histCountsPerBucket :: !(Map.Map Bucket Int)
 } deriving (Show, Eq, Ord)
 
 emptyCounts :: [Bucket] -> BucketCounts


### PR DESCRIPTION
While `withHistogram` as well as the `histCountsPerBucket` `Map` both try to be very strict, the _field_ `histCountsPerBucket` itself is not, causing a space leak in `withHistogram` in my application. I figure the easiest solution is to just strictify the field itself, unless the intention is really to delegate the responsibility to `f`?