### PR TITLE
Measure GHC metrics with less polling

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,1 @@
+packages: */*.cabal


### PR DESCRIPTION
Instead of calling `getStats` per metric, call it only once per sampling interval.

Also don't create metrics at all if RTS stats are not available.