### PR TITLE
Expose Bucket type synonym

### DIFF
--- a/prometheus-client/CHANGELOG.md
+++ b/prometheus-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+Expose the `Bucket` type
+
 ## 1.0.0.1 -- 2020-05-27
 
 - Optimizations to improve memory usage.

--- a/prometheus-client/src/Prometheus.hs
+++ b/prometheus-client/src/Prometheus.hs
@@ -117,6 +117,7 @@ module Prometheus (
 -- >>> getHistogram myHistogram
 -- fromList [(5.0e-3,1),(1.0e-2,0),(2.5e-2,0),(5.0e-2,0),(0.1,0),(0.25,0),(0.5,0),(1.0,0),(2.5,0),(5.0,0),(10.0,0)]
 ,   Histogram
+,   Bucket
 ,   histogram
 ,   defaultBuckets
 ,   exponentialBuckets

--- a/prometheus-client/src/Prometheus/Metric/Histogram.hs
+++ b/prometheus-client/src/Prometheus/Metric/Histogram.hs
@@ -3,6 +3,7 @@
 
 module Prometheus.Metric.Histogram (
     Histogram
+,   Bucket
 ,   histogram
 ,   defaultBuckets
 ,   exponentialBuckets


### PR DESCRIPTION
Currently Bucket is referenced in type signatures in Prometheus, but it's not exported. I think this was probably just an oversight.

I tested this by running stack haddock and verifying Bucket shows up, and is linked to correctly.

I searched Stackage and other uses of the word "Bucket" aren't in Base or anything, so it's unlikely that exporting this will cause naming collisions https://www.stackage.org/lts-16.1/hoogle?q=Bucket

I'm not sure what your release policy is. I just added my change to the unreleased section of the changelog for now, but I'm happy to bump the version in the cabal file if you'd like