### PR TITLE
Update travis to use stack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,53 +1,45 @@
 notifications:
   email: false
 
+# Use new container infrastructure to enable caching
+sudo: false
+
+# Choose a lightweight base image; we provide our own build tools.
+language: c
+
+# GHC depends on GMP. You can add other dependencies here as well.
+addons:
+  apt:
+    packages:
+    - libgmp-dev
+
+# The different configurations we want to test. You could also do things like
+# change flags or use --stack-yaml to point to a different file.
 env:
- - CABALVER=1.18 GHCVER=7.8.4
- - CABALVER=1.22 GHCVER=7.10.2
- - CABALVER=2.2 GHCVER=8.4.2
+  global:
+    - ARGS="--no-terminal --install-ghc"
+    - STACK_URL="https://www.stackage.org/stack/linux-x86_64"
+  matrix:
+    - YAML="./stack.yaml"               CMD="bench prometheus-client"
+    - YAML="./stack.yaml"               CMD="test --haddock"
+    - YAML="./.travis/stack-lts-2.yaml" CMD="test --haddock" STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v1.5.1/stack-1.5.1-linux-x86_64-static.tar.gz"
+    - YAML="./.travis/stack-lts-3.yaml" CMD="test --haddock" STACK_URL="https://github.com/commercialhaskell/stack/releases/download/v1.5.1/stack-1.5.1-linux-x86_64-static.tar.gz"
+    - YAML="./.travis/stack-lts-12.yaml" CMD="test --haddock"
+    - YAML="./.travis/stack-lts-16.yaml" CMD="test --haddock"
 
 before_install:
- - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
- - travis_retry sudo apt-get update
- - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER # see note about happy/alex
- - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+# Download and unpack the stack executable
+- mkdir -p ~/.local/bin
+- export PATH=$HOME/.local/bin:$PATH
+- travis_retry curl -L $STACK_URL | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 
-install:
- - cabal --version
- - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
- - travis_retry cabal update
-
-before_script:
-  - wget https://www.stackage.org/lts/cabal.config
-  - cabal sandbox init
-  - cabal sandbox add-source prometheus-client
-  - cabal sandbox add-source prometheus-metrics-ghc
-  - cabal sandbox add-source wai-middleware-prometheus
-
-  - cd prometheus-client
-  - cabal sandbox init --sandbox ../.cabal-sandbox
-  - cabal install --only-dependencies --enable-benchmarks --enable-tests
-  - cabal configure --enable-tests
-
-  - cd ../prometheus-metrics-ghc
-  - cabal sandbox init --sandbox ../.cabal-sandbox
-  - cabal install --only-dependencies --enable-benchmarks --enable-tests
-  - cabal configure --enable-tests
-
-  - cd ../wai-middleware-prometheus
-  - cabal sandbox init --sandbox ../.cabal-sandbox
-  - cabal install --only-dependencies --enable-benchmarks --enable-tests
-  - cabal configure --enable-tests
-
-  - cd ../example
-  - cabal sandbox init --sandbox ../.cabal-sandbox
-  - cabal install --only-dependencies --enable-benchmarks --enable-tests
-  - cabal configure --enable-tests
-
-  - cd ..
-
+# This line does all of the work: installs GHC if necessary, build the library,
+# executables, and test suites, and runs the test suites. --no-terminal works
+# around some quirks in Travis's terminal implementation.
 script:
-  - cd prometheus-client && cabal build && cabal test
-  - cd ../prometheus-metrics-ghc && cabal build && cabal test
-  - cd ../wai-middleware-prometheus && cabal build && cabal test
-  - cd ../example && cabal build
+- stack --stack-yaml $YAML $ARGS $CMD
+
+# Caching so the next build will be fast too.
+cache:
+  directories:
+  - $HOME/.stack

--- a/.travis/stack-lts-12.yaml
+++ b/.travis/stack-lts-12.yaml
@@ -1,0 +1,10 @@
+flags: {}
+packages:
+- ../example/
+- ../prometheus-client
+- ../prometheus-metrics-ghc
+- ../prometheus-proc
+- ../wai-middleware-prometheus
+extra-deps:
+- unix-memory-0.1.2
+resolver: lts-12.26

--- a/.travis/stack-lts-16.yaml
+++ b/.travis/stack-lts-16.yaml
@@ -1,0 +1,10 @@
+flags: {}
+packages:
+- ../example/
+- ../prometheus-client
+- ../prometheus-metrics-ghc
+- ../prometheus-proc
+- ../wai-middleware-prometheus
+extra-deps:
+- unix-memory-0.1.2
+resolver: lts-16.6

--- a/.travis/stack-lts-2.yaml
+++ b/.travis/stack-lts-2.yaml
@@ -1,0 +1,10 @@
+flags: {}
+packages:
+- ../example/
+- ../prometheus-client
+- ../prometheus-metrics-ghc
+- ../wai-middleware-prometheus
+extra-deps:
+- atomic-primops-0.8.2
+- clock-0.8
+resolver: lts-2.22

--- a/.travis/stack-lts-3.yaml
+++ b/.travis/stack-lts-3.yaml
@@ -1,0 +1,9 @@
+flags: {}
+packages:
+- ../example/
+- ../prometheus-client
+- ../prometheus-metrics-ghc
+- ../wai-middleware-prometheus
+extra-deps:
+- clock-0.8
+resolver: lts-3.22

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,4 +5,6 @@ packages:
 - prometheus-metrics-ghc
 - prometheus-proc
 - wai-middleware-prometheus
+extra-deps:
+- unix-memory-0.1.2
 resolver: lts-11.2

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,8 @@
 flags: {}
 packages:
-- prometheus-metrics-ghc/
-- wai-middleware-prometheus/
 - example/
-- prometheus-client/
+- prometheus-client
+- prometheus-metrics-ghc
+- prometheus-proc
+- wai-middleware-prometheus
 resolver: lts-11.2

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,4 +7,4 @@ packages:
 - wai-middleware-prometheus
 extra-deps:
 - unix-memory-0.1.2
-resolver: lts-11.2
+resolver: lts-12.14


### PR DESCRIPTION
This should hopefully be more reliable than the previous cabalsandbox
approach since package resolution is locked and do not change over time.