### PR TITLE
Replace Summary algorithm with improved implementation

### DIFF
--- a/prometheus-client/prometheus-client.cabal
+++ b/prometheus-client/prometheus-client.cabal
@@ -41,6 +41,7 @@ library
     , clock
     , containers
     , deepseq
+    , primitive
     , mtl                >=2
     , stm                >=2.3
     , transformers
@@ -48,6 +49,7 @@ library
     , utf8-string
     , exceptions
     , text
+    , data-sketches
   ghc-options: -Wall
 
 test-suite doctest
@@ -83,6 +85,8 @@ test-suite spec
     , deepseq
     , exceptions
     , text
+    , primitive
+    , data-sketches
   ghc-options: -Wall
 
 benchmark bench

--- a/prometheus-client/prometheus-client.cabal
+++ b/prometheus-client/prometheus-client.cabal
@@ -1,5 +1,5 @@
 name:                prometheus-client
-version:             1.0.1
+version:             1.1.0
 synopsis:            Haskell client library for http://prometheus.io.
 description:         Haskell client library for http://prometheus.io.
 homepage:            https://github.com/fimad/prometheus-haskell

--- a/prometheus-client/src/Prometheus/Metric/Summary.hs
+++ b/prometheus-client/src/Prometheus/Metric/Summary.hs
@@ -1,8 +1,5 @@
 {-# language BangPatterns #-}
-{-# language DataKinds #-}
 {-# language OverloadedStrings #-}
-{-# language TypeApplications #-}
-{-# language TypeOperators #-}
 module Prometheus.Metric.Summary (
     Summary
 ,   Quantile

--- a/prometheus-client/src/Prometheus/Metric/Summary.hs
+++ b/prometheus-client/src/Prometheus/Metric/Summary.hs
@@ -26,11 +26,14 @@ import Control.Monad.Primitive
 import qualified Data.ByteString.UTF8 as BS
 import qualified Data.Text as T
 import DataSketches.Quantiles.RelativeErrorQuantile
-import DataSketches.Quantiles.RelativeErrorQuantile.Types
 import qualified DataSketches.Quantiles.RelativeErrorQuantile as ReqSketch
+import Data.Maybe (mapMaybe)
+import Prelude hiding (maximum)
+import qualified Prelude
+import Data.Word
 
-data Summary = MkSummary 
-  { reqSketch :: MVar (ReqSketch 6 (PrimState IO))
+data Summary = MkSummary
+  { reqSketch :: MVar (ReqSketch (PrimState IO))
   , quantiles :: [Quantile]
   }
 
@@ -40,32 +43,47 @@ instance NFData Summary where
 
 type Quantile = (Rational, Rational)
 
+determineK :: Quantile -> Maybe Word32
+determineK (rank_, acceptableError) = go 4
+    where
+        go k =
+            let rse = relativeStandardError (fromIntegral k) (fromRational rank_) HighRanksAreAccurate 50000
+            in if abs (rse - fromRational rank_) <= fromRational acceptableError
+                then Just k
+                else if k < 1024
+                    then go (k + 2)
+                    else Nothing
+
+
 -- | Creates a new summary metric with a given name, help string, and a list of
 -- quantiles. A reasonable set set of quantiles is provided by
 -- 'defaultQuantiles'.
 summary :: Info -> [Quantile] -> Metric Summary
 summary info quantiles_ = Metric $ do
-    -- valueTVar <- STM.newTVarIO (emptyEstimator quantiles)
-    rs <- mkReqSketch @6 HighRanksAreAccurate
-    mv <- newMVar (rs {criterion = (:<=)})
+    rs <- mkReqSketch kInt HighRanksAreAccurate
+    mv <- newMVar $ rs {criterion = (:<=)}
     let summary_ = MkSummary mv quantiles_
     return (summary_, collectSummary info summary_)
+    where
+        kInt = fromIntegral $ case mapMaybe determineK quantiles_ of
+          [] -> error "Unable to create a Summary meeting the provided quantile precision requirements"
+          xs -> Prelude.maximum xs
 
 instance Observer Summary where
     -- | Adds a new observation to a summary metric.
-    observe s v = doIO $ withMVar (reqSketch s) (`update` v)
+    observe s v = doIO $ withMVar (reqSketch s) (`ReqSketch.insert` v)
 
 -- | Retrieves a list of tuples containing a quantile and its associated value.
 getSummary :: MonadIO m => Summary -> m [(Rational, Double)]
 getSummary (MkSummary sketchVar quantiles_) = liftIO $ withMVar sketchVar $ \sketch -> do
-  forM quantiles_ $ \qv -> 
+  forM quantiles_ $ \qv ->
     (,) <$> pure (fst qv) <*> ReqSketch.quantile sketch (fromRational $ fst qv)
 
 collectSummary :: Info -> Summary -> IO [SampleGroup]
 collectSummary info (MkSummary sketchVar quantiles_) = withMVar sketchVar $ \sketch -> do
-    itemSum <- getSum sketch
-    count_ <- getN sketch
-    estimatedQuantileValues <- forM quantiles_ $ \qv -> 
+    itemSum <- ReqSketch.sum sketch
+    count_ <- ReqSketch.count sketch
+    estimatedQuantileValues <- forM quantiles_ $ \qv ->
       (,) <$> pure (fst qv) <*> ReqSketch.quantile sketch (toDouble $ fst qv)
     let sumSample = Sample (metricName info <> "_sum") [] (bsShow itemSum)
     let countSample = Sample (metricName info <> "_count") [] (bsShow count_)

--- a/prometheus-client/src/Prometheus/Metric/Summary.hs
+++ b/prometheus-client/src/Prometheus/Metric/Summary.hs
@@ -44,7 +44,7 @@ instance NFData Summary where
 type Quantile = (Rational, Rational)
 
 determineK :: Quantile -> Maybe Word32
-determineK (rank_, acceptableError) = go 4
+determineK (rank_, acceptableError) = go 6
     where
         go k =
             let rse = relativeStandardError (fromIntegral k) (fromRational rank_) HighRanksAreAccurate 50000

--- a/prometheus-client/src/Prometheus/Metric/Summary.hs
+++ b/prometheus-client/src/Prometheus/Metric/Summary.hs
@@ -1,5 +1,7 @@
 {-# language BangPatterns #-}
+{-# language DataKinds #-}
 {-# language OverloadedStrings #-}
+{-# language TypeApplications #-}
 
 module Prometheus.Metric.Summary (
     Summary
@@ -9,15 +11,6 @@ module Prometheus.Metric.Summary (
 ,   observe
 ,   observeDuration
 ,   getSummary
-
-,   dumpEstimator
-,   emptyEstimator
-,   Estimator (..)
-,   Item (..)
-,   insert
-,   compress
-,   query
-,   invariant
 ) where
 
 import Prometheus.Info
@@ -25,171 +18,70 @@ import Prometheus.Metric
 import Prometheus.Metric.Observer
 import Prometheus.MonadMonitor
 
-import qualified Control.Concurrent.STM as STM
+import Control.Concurrent.MVar
 import Control.DeepSeq
+import Control.Monad
 import Control.Monad.IO.Class
+import Control.Monad.Primitive
 import qualified Data.ByteString.UTF8 as BS
 import Data.Foldable (foldr')
 import Data.Int (Int64)
 import Data.Monoid ((<>))
 import qualified Data.Text as T
+import DataSketches.Quantiles.RelativeErrorQuantile
+import qualified DataSketches.Quantiles.RelativeErrorQuantile as ReqSketch
 
-
-newtype Summary = MkSummary (STM.TVar Estimator)
+data Summary = MkSummary 
+  { reqSketch :: MVar (ReqSketch 6 (PrimState IO))
+  , quantiles :: [Quantile]
+  }
 
 instance NFData Summary where
-  rnf (MkSummary a) = a `seq` ()
+  rnf (MkSummary a b) = a `seq` b `seq` ()
+
+
+type Quantile = (Rational, Rational)
 
 -- | Creates a new summary metric with a given name, help string, and a list of
 -- quantiles. A reasonable set set of quantiles is provided by
 -- 'defaultQuantiles'.
 summary :: Info -> [Quantile] -> Metric Summary
 summary info quantiles = Metric $ do
-    valueTVar <- STM.newTVarIO (emptyEstimator quantiles)
-    return (MkSummary valueTVar, collectSummary info valueTVar)
-
-withSummary :: MonadMonitor m
-            => Summary -> (Estimator -> Estimator) -> m ()
-withSummary (MkSummary !valueTVar) f =
-    doIO $ STM.atomically $ do
-        STM.modifyTVar' valueTVar compress
-        STM.modifyTVar' valueTVar f
+    -- valueTVar <- STM.newTVarIO (emptyEstimator quantiles)
+    mv <- newMVar =<< mkReqSketch @6 HighRanksAreAccurate
+    let summary_ = MkSummary mv quantiles
+    return (summary_, collectSummary info summary_)
 
 instance Observer Summary where
     -- | Adds a new observation to a summary metric.
-    observe s v = withSummary s (insert v)
+    observe s v = doIO $ withMVar (reqSketch s) (\s -> update s v)
 
 -- | Retrieves a list of tuples containing a quantile and its associated value.
 getSummary :: MonadIO m => Summary -> m [(Rational, Double)]
-getSummary (MkSummary valueTVar) = liftIO $ do
-    estimator <- STM.atomically $ do
-        STM.modifyTVar' valueTVar compress
-        STM.readTVar valueTVar
-    let quantiles = map fst $ estQuantiles estimator
-    let values = map (query estimator) quantiles
-    return $ zip quantiles values
+getSummary (MkSummary sketchVar quantiles) = liftIO $ withMVar sketchVar $ \sketch -> do
+  forM quantiles $ \qv -> 
+    (,) <$> pure (fst qv) <*> ReqSketch.quantile sketch (fromRational $ fst qv)
 
-collectSummary :: Info -> STM.TVar Estimator -> IO [SampleGroup]
-collectSummary info valueTVar = STM.atomically $ do
-    STM.modifyTVar' valueTVar compress
-    estimator@(Estimator count itemSum _ _) <- STM.readTVar valueTVar
-    let quantiles = map fst $ estQuantiles estimator
-    let samples =  map (toSample estimator) quantiles
+collectSummary :: Info -> Summary -> IO [SampleGroup]
+collectSummary info (MkSummary sketchVar quantiles) = withMVar sketchVar $ \sketch -> do
+    itemSum <- getSum sketch
+    count <- getN sketch
+    estimatedQuantileValues <- forM quantiles $ \qv -> 
+      (,) <$> pure (fst qv) <*> ReqSketch.quantile sketch (toDouble $ fst qv)
     let sumSample = Sample (metricName info <> "_sum") [] (bsShow itemSum)
     let countSample = Sample (metricName info <> "_count") [] (bsShow count)
-    return [SampleGroup info SummaryType $ samples ++ [sumSample, countSample]]
+    return [SampleGroup info SummaryType $ map toSample estimatedQuantileValues ++ [sumSample, countSample]]
     where
         bsShow :: Show s => s -> BS.ByteString
         bsShow = BS.fromString . show
 
-        toSample estimator q =
+        toSample :: (Rational, Double) -> Sample
+        toSample (q, estimatedValue) =
             Sample (metricName info) [("quantile", T.pack . show $ toDouble q)] $
-                bsShow $ query estimator q
+                bsShow estimatedValue
 
         toDouble :: Rational -> Double
         toDouble = fromRational
 
-dumpEstimator :: Summary -> IO Estimator
-dumpEstimator (MkSummary valueTVar) =
-    STM.atomically $ STM.readTVar valueTVar
-
--- | A quantile is a pair of a quantile value and an associated acceptable error
--- value.
-type Quantile = (Rational, Rational)
-
-data Item = Item {
-    itemValue :: Double
-,   itemG     :: !Int64
-,   itemD     :: !Int64
-} deriving (Eq, Show)
-
-instance Ord Item where
-    compare a b = itemValue a `compare` itemValue b
-
-data Estimator = Estimator {
-    estCount      :: !Int64
-,   estSum        :: !Double
-,   estQuantiles  :: [Quantile]
-,   estItems      :: [Item]
-} deriving (Show)
-
 defaultQuantiles :: [Quantile]
 defaultQuantiles = [(0.5, 0.05), (0.9, 0.01), (0.99, 0.001)]
-
-emptyEstimator :: [Quantile] -> Estimator
-emptyEstimator quantiles = Estimator 0 0 quantiles []
-
-insert :: Double -> Estimator -> Estimator
-insert value estimator@(Estimator oldCount oldSum quantiles items) =
-        newEstimator $ insertItem 0 items
-    where
-        newEstimator = Estimator (oldCount + 1) (oldSum + value) quantiles
-
-        insertItem _ [] = [Item value 1 0]
-        insertItem r [x]
-            -- The first two cases cover the scenario where the initial size of
-            -- the list is one.
-            | r == 0 && value < itemValue x = Item value 1 0 : [x]
-            | r == 0                        = x : [Item value 1 0]
-            -- The last case covers the scenario where the we have walked off
-            -- the end of a list with more than 1 element in the final case of
-            -- insertItem in which case we already know that x < value.
-            | otherwise                     = x : [Item value 1 0]
-        insertItem r (x:y:xs)
-            -- This first case only covers the scenario where value is less than
-            -- the first item in a multi-item list. For subsequent steps of
-            -- a multi valued list, this case cannot happen as it would have
-            -- fallen through to the case below in the previous step.
-            | value <= itemValue x = Item value 1 0 : x : y : xs
-            | value <= itemValue y = x : Item value 1 (calcD $ r + itemG x)
-                                       : y : xs
-            | otherwise            = x : insertItem (itemG x + r) (y : xs)
-
-        calcD r = max 0
-                $ floor (invariant estimator (fromIntegral r)) - 1
-
-
-compress :: Estimator -> Estimator
-compress est@(Estimator _ _ _ [])    = est
-compress est@(Estimator _ _ _ items) = est {
-        estItems = (minItem :)
-                 $ foldr' compressPair []
-                 $ drop 1  -- The exact minimum item must be kept exactly.
-                 $ zip items
-                 $ scanl (+) 0 (map itemG items)
-    }
-    where
-        minItem = head items
-        compressPair (a, _) [] = [a]
-        compressPair (a@(Item _ aG _), r) (b@(Item bVal bG bD):bs)
-            | bD == 0             = a : b : bs
-            | aG + bG + bD <= inv = Item bVal (aG + bG) bD : bs
-            | otherwise           = a : b : bs
-            where
-                inv = floor $ invariant est (fromIntegral r)
-
-query :: Estimator -> Rational -> Double
-query est@(Estimator count _ _ items) q = findQuantile allRs items
-    where
-        allRs = scanl (+) 0 $ map itemG items
-
-        n = fromIntegral count
-        f = invariant est
-
-        rank  = q * n
-        bound = rank + (f rank / 2)
-
-        findQuantile _        []   = 0 / 0  -- NaN
-        findQuantile _        [a]  = itemValue a
-        findQuantile (_:bR:rs) (a@(Item{}):b@(Item _ bG bD):xs)
-            | fromIntegral (bR + bG + bD) > bound = itemValue a
-            | otherwise            = findQuantile (bR:rs) (b:xs)
-        findQuantile _        _    = error "Query impossibility"
-
-invariant :: Estimator -> Rational -> Rational
-invariant (Estimator count _ quantiles _) r = max 1
-                                            $ minimum $ map fj quantiles
-    where
-        n = fromIntegral count
-        fj (q, e) | q * n <= r = 2 * e * r / q
-                  | otherwise  = 2 * e * (n - r) / (1 - q)

--- a/prometheus-client/tests/Prometheus/Metric/SummarySpec.hs
+++ b/prometheus-client/tests/Prometheus/Metric/SummarySpec.hs
@@ -112,7 +112,6 @@ checkQuantiles :: Summary
                -> Double
                -> [(Rational, Rational, Double)] -> IO ()
 checkQuantiles m windowSize values = do
-    -- estimator <- dumpEstimator m
     forM_ values $ \(q, e, actual) -> do
         let expected = fromIntegral $ (ceiling $ fromRat q * windowSize :: Int) - 1
         let minValue = expected - (fromRat e * windowSize)
@@ -123,11 +122,6 @@ checkQuantiles m windowSize values = do
                 ,   " was not within acceptable error range (", show e , "). "
                 ,   "Got ", show actual, ", but wanted ", show expected
                 ,   " (", show minValue, " <= v <= ", show maxValue, ")."
-                {-
-                ,   if estCount estimator <= 100
-                        then "\nEstimator = " ++ show estimator
-                        else ""
-                -}
                 ]
 
 quantiles :: [Quantile]

--- a/prometheus-metrics-ghc/prometheus-metrics-ghc.cabal
+++ b/prometheus-metrics-ghc/prometheus-metrics-ghc.cabal
@@ -25,7 +25,7 @@ library
       Prometheus.Metric.GHC
   build-depends:
       base               >=4.7 && <5
-    , prometheus-client  >=1.0.0 && <1.1
+    , prometheus-client  >=1.0.0 && <1.2
     , utf8-string        >=0.3
     , text
   ghc-options: -Wall

--- a/prometheus-proc/prometheus-proc.cabal
+++ b/prometheus-proc/prometheus-proc.cabal
@@ -20,7 +20,7 @@ library
   build-depends:       base >=4.10 && <4.15
                      , directory >= 1.2.5.0 && < 1.4
                      , filepath >=1.4 && <1.5
-                     , prometheus-client >= 1.0.0 && < 1.1
+                     , prometheus-client >= 1.0.0 && < 1.2
                      , regex-applicative >=0.3 && <0.4
                      , text >= 0.7 && < 1.3
                      , unix >=2.7 && <2.8

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,4 +7,5 @@ packages:
 - wai-middleware-prometheus
 extra-deps:
 - unix-memory-0.1.2
-resolver: lts-12.14
+- data-sketches-0.1.0.0
+resolver: lts-18.5

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,5 +7,5 @@ packages:
 - wai-middleware-prometheus
 extra-deps:
 - unix-memory-0.1.2
-- data-sketches-0.1.0.0
+- data-sketches-0.3.0.0
 resolver: lts-18.5

--- a/wai-middleware-prometheus/wai-middleware-prometheus.cabal
+++ b/wai-middleware-prometheus/wai-middleware-prometheus.cabal
@@ -29,7 +29,7 @@ library
     , clock
     , data-default
     , http-types
-    , prometheus-client  >=1.0.0 && <1.1
+    , prometheus-client  >=1.0.0 && <1.2
     , text               >=0.11
     , wai                >=3.0
   ghc-options: -Wall


### PR DESCRIPTION
## Context
Workers systems in our Haskell codebase were exhibiting dramatic slowdowns over time when using summary metrics. Through heap profiling, we determined that the culprit was the particular algorithm in use by `prometheus-client` having linear memory growth for "adversarial" inputs, such as repeating duplicate numbers, monotonically increasing values, and monotonically decreasing values:

This was our worker heap profile for repeated observations of the value `1`:

![image](https://user-images.githubusercontent.com/69209/130689107-11612e43-e7a7-4cad-8262-09ed8f951ab9.png)

We found through a Rust implementation of the same algorithm (CKMS) that the targeted quantile variant in use is fundamentally flawed, and it pointed us to [bq-pods.pdf](https://github.com/MercuryTechnologies/mercury-web-backend/files/7040272/bq-pods.pdf) this paper as the followup research by the same authors that solved the problem. Unfortunately, the paper assumed the use of effectively bounded ranges of possible inputs to make its sublinear memory growth guarantees, and wasn't practically implementable. We contacted the authors of the paper, and Graham Cormode provided us with a link to the [latest work in this line](https://arxiv.org/abs/1907.00236), and thankfully it also had [publicly available code](https://datasketches.apache.org/) under the Apache foundation. We ported over the `ReqSketch` implementation to Haskell and have it published as a package [on Hackage](https://hackage.haskell.org/package/data-sketches-0.1.0.1)

## How We Tested

We ported the tests from the Java implementation to our version here: https://github.com/iand675/datasketches-haskell/tree/main/test

Benchmarks in the general case (ReqSketch/insert/mvar) vs (Prometheus/insert/existing) show dramatic performance increases (~257x) over the existing Prometheus code.

![image](https://user-images.githubusercontent.com/69209/130644037-dc5284fb-2552-479c-8334-0901c142a067.png)

We also ran tests to ensure sublinear growth, and in the adversarial case of repeated inserts of the same value, we are seeing the desired behaviour for the new implementation:

``` haskell
sk <- mkReqSketch 6 HighRanksAreAccurate
replicateM_ 100_000_000 (update sk 1)
print =<< getRetainedItems
```
Returns
```
937
```

We also tested against our workers locally with the new algorithm, and we're seeing consistent garbage collection / memory usage when processing 100k webhooks. To be clear, this is the same workload as the graph posted above, the only difference is the usage of the new quantile estimation algorithm.

![image](https://user-images.githubusercontent.com/69209/130644982-87a5fbe7-1511-4633-b10e-65444299047b.png)

