### PR TITLE
Fix async interrupt breaking bookkeeping in a Summary

### DIFF
--- a/prometheus-client/src/Prometheus/Metric/Summary.hs
+++ b/prometheus-client/src/Prometheus/Metric/Summary.hs
@@ -79,7 +79,7 @@ summary info quantiles_ = Metric $ do
 
 instance Observer Summary where
     -- | Adds a new observation to a summary metric.
-    observe s v = doIO $ withMVar (reqSketch s) (`ReqSketch.insert` v)
+    observe s v = doIO $ withMVarMasked (reqSketch s) (\rs -> rs `ReqSketch.insert` v)
 
 -- | Retrieves a list of tuples containing a quantile and its associated value.
 getSummary :: MonadIO m => Summary -> m [(Rational, Double)]


### PR DESCRIPTION
We ran into an alert where an internal invariant had been broken in the `ReqSketch` library. As best as we can tell, it was triggered by an async interrupt causing an internal counter and array length to become out of sync.