### PR TITLE
Change metric type to Gauge for GC memory in use.

### DIFF
--- a/prometheus-metrics-ghc/src/Prometheus/Metric/GHC.hs
+++ b/prometheus-metrics-ghc/src/Prometheus/Metric/GHC.hs
@@ -300,7 +300,7 @@ ghcCollectors = [
     , statsCollector
             "ghc_gcdetails_mem_in_use_bytes"
             "Total amount of memory in use by the RTS"
-            CounterType
+            GaugeType
             (gcdetails_mem_in_use_bytes . gc)
     , statsCollector
             "ghc_gcdetails_copied_bytes"


### PR DESCRIPTION
Running `promtool check` on the output of `prometheus-metrics-ghc` using GHC 9.0.2 gave me a warning on the `ghc_gcdetails_mem_in_use_bytes` metric. I think it would be better for this metric to be a gauge, since it doesn't really have the semantics of a counter.