### PR TITLE
Update for mtl-2.3

### DIFF
--- a/prometheus-client/src/Prometheus/MonadMonitor.hs
+++ b/prometheus-client/src/Prometheus/MonadMonitor.hs
@@ -14,7 +14,6 @@ import Control.Applicative (Applicative)
 import Control.Monad.Identity (Identity, runIdentity)
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Class (MonadTrans)
-import Control.Monad.Trans.Error (ErrorT, Error)
 import Control.Monad.Trans.Except (ExceptT)
 import Control.Monad.Trans.Identity (IdentityT)
 import Control.Monad.Trans.Maybe (MaybeT)
@@ -39,7 +38,6 @@ class Monad m => MonadMonitor m where
 instance MonadMonitor IO where
     doIO = id
 
-instance (Error e, MonadMonitor m) => MonadMonitor (ErrorT e m)
 instance (MonadMonitor m) => MonadMonitor (ExceptT e m)
 instance (MonadMonitor m) => MonadMonitor (IdentityT m)
 instance (MonadMonitor m) => MonadMonitor (MaybeT m)


### PR DESCRIPTION
`Control.Monad.Trans.Error` is deprecated and was removed