### PR TITLE
Add exemplars

### DIFF
--- a/prometheus-client/src/Prometheus.hs
+++ b/prometheus-client/src/Prometheus.hs
@@ -125,6 +125,7 @@ module Prometheus (
 ,   linearBuckets
 ,   getHistogram
 ,   observeWithExemplar
+,   ExemplarMetadata(..)
 
 -- ** Vector
 --

--- a/prometheus-client/src/Prometheus.hs
+++ b/prometheus-client/src/Prometheus.hs
@@ -201,7 +201,7 @@ module Prometheus (
 -- >>> newtype CPUTime = MkCPUTime ()
 -- >>> let info = Info "cpu_time" "The current CPU time"
 -- >>> let toValue = Data.ByteString.UTF8.fromString . show
--- >>> let toSample = Sample "cpu_time" [] . toValue
+-- >>> let toSample x = Sample "cpu_time" [] (toValue x) []
 -- >>> let toSampleGroup = (:[]) . SampleGroup info GaugeType . (:[]) . toSample
 -- >>> let collectCPUTime = fmap toSampleGroup getCPUTime
 -- >>> let cpuTimeMetric = Metric (return (MkCPUTime (), collectCPUTime))

--- a/prometheus-client/src/Prometheus.hs
+++ b/prometheus-client/src/Prometheus.hs
@@ -123,6 +123,7 @@ module Prometheus (
 ,   exponentialBuckets
 ,   linearBuckets
 ,   getHistogram
+,   observeWithExemplar
 
 -- ** Vector
 --

--- a/prometheus-client/src/Prometheus.hs
+++ b/prometheus-client/src/Prometheus.hs
@@ -203,7 +203,7 @@ module Prometheus (
 -- >>> newtype CPUTime = MkCPUTime ()
 -- >>> let info = Info "cpu_time" "The current CPU time"
 -- >>> let toValue = Data.ByteString.UTF8.fromString . show
--- >>> let toSample x = Sample "cpu_time" [] (toValue x) []
+-- >>> let toSample x = Sample "cpu_time" [] (toValue x) Nothing
 -- >>> let toSampleGroup = (:[]) . SampleGroup info GaugeType . (:[]) . toSample
 -- >>> let collectCPUTime = fmap toSampleGroup getCPUTime
 -- >>> let cpuTimeMetric = Metric (return (MkCPUTime (), collectCPUTime))

--- a/prometheus-client/src/Prometheus/Export/Text.hs
+++ b/prometheus-client/src/Prometheus/Export/Text.hs
@@ -68,17 +68,17 @@ exportSample (Sample name labels value exemplarLabelPairs) =
     <> buildLabelPairs labels
     <> Build.charUtf8 ' '
     <> Build.byteString value
-    <> case exemplarLabelPairs of
-         [] -> mempty
-         xs -> (Build.byteString " # ") <> buildLabelPairs exemplarLabelPairs
+    <> if null exemplarLabelPairs 
+         then mempty 
+         else Build.byteString " # " <> buildLabelPairs exemplarLabelPairs
 
-  where buildLabelPairs labelPairs = (case labelPairs of
+  where buildLabelPairs labelPairs = case labelPairs of
          [] -> mempty
          l:ls ->
            Build.charUtf8 '{'
              <> exportLabel l
              <> mconcat [ Build.charUtf8 ',' <> exportLabel l' | l' <- ls ]
-             <> Build.charUtf8 '}')
+             <> Build.charUtf8 '}'
 
 exportLabel :: (Text, Text) -> Build.Builder
 exportLabel (key, value) =

--- a/prometheus-client/src/Prometheus/Export/Text.hs
+++ b/prometheus-client/src/Prometheus/Export/Text.hs
@@ -63,17 +63,22 @@ exportSamples samples =
   mconcat [ exportSample s <> Build.charUtf8 '\n' | s <- samples ]
 
 exportSample :: Sample -> Build.Builder
-exportSample (Sample name labels value) =
+exportSample (Sample name labels value exemplarLabelPairs) =
   Build.byteString (T.encodeUtf8 name)
-    <> (case labels of
+    <> buildLabelPairs labels
+    <> Build.charUtf8 ' '
+    <> Build.byteString value
+    <> case exemplarLabelPairs of
+         [] -> mempty
+         xs -> (Build.byteString " # ") <> buildLabelPairs exemplarLabelPairs
+
+  where buildLabelPairs labelPairs = (case labelPairs of
          [] -> mempty
          l:ls ->
            Build.charUtf8 '{'
              <> exportLabel l
              <> mconcat [ Build.charUtf8 ',' <> exportLabel l' | l' <- ls ]
              <> Build.charUtf8 '}')
-    <> Build.charUtf8 ' '
-    <> Build.byteString value
 
 exportLabel :: (Text, Text) -> Build.Builder
 exportLabel (key, value) =

--- a/prometheus-client/src/Prometheus/Export/Text.hs
+++ b/prometheus-client/src/Prometheus/Export/Text.hs
@@ -17,7 +17,7 @@ import Data.Monoid ((<>), mempty, mconcat)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
-
+import System.Clock
 
 -- $setup
 -- >>> :module +Prometheus
@@ -85,16 +85,33 @@ exportSamples samples =
   mconcat [ exportSample s <> Build.charUtf8 '\n' | s <- samples ]
 
 exportSample :: Sample -> Build.Builder
-exportSample (Sample name labels value exemplarLabelPairs) =
+exportSample (Sample name labels value mExemplar) =
   Build.byteString (T.encodeUtf8 name)
     <> buildLabelPairs labels
     <> Build.charUtf8 ' '
     <> Build.byteString value
-    <> if null exemplarLabelPairs 
-         then mempty 
-         else Build.byteString " # " <> buildLabelPairs exemplarLabelPairs
+    <> case mExemplar of
+         Nothing -> mempty
+         Just exemplar -> encodeExemplar exemplar
 
-  where buildLabelPairs labelPairs = case labelPairs of
+  where 
+        encodeExemplar :: SampleExemplar -> Build.Builder
+        encodeExemplar (SampleExemplar labelPairs exemplarValue mTimestamp) = 
+             Build.byteString " # "
+          <> buildLabelPairs labelPairs
+          <> Build.charUtf8 ' '
+          <> Build.byteString exemplarValue
+          <> case mTimestamp of
+               Nothing -> mempty
+               Just timestamp -> Build.charUtf8 ' ' <> encodeTimespec timestamp
+
+        encodeTimespec :: TimeSpec -> Build.Builder
+        encodeTimespec timespec = 
+          Build.int64Dec (sec timespec) 
+          <> Build.charUtf8 '.'
+          <> Build.int64Dec (nsec timespec)
+
+        buildLabelPairs labelPairs = case labelPairs of
          [] -> mempty
          l:ls ->
            Build.charUtf8 '{'

--- a/prometheus-client/src/Prometheus/Label.hs
+++ b/prometheus-client/src/Prometheus/Label.hs
@@ -14,8 +14,6 @@ module Prometheus.Label (
 ,   Label7
 ,   Label8
 ,   Label9
-,   traceLabel
-,   traceAndSpanLabels
 ) where
 
 import Data.Text
@@ -90,9 +88,3 @@ instance (a ~ Text, b ~ a, c ~ a, d ~ a, e ~ a, f ~ a, g ~ a, h ~ a, i ~ a) => L
                (v1, v2, v3, v4, v5, v6, v7, v8, v9) =
             [(k1, v1), (k2, v2), (k3, v3), (k4, v4), (k5, v5), (k6, v6),
              (k7, v7), (k8, v8), (k9, v9)]
-
-traceLabel :: Text -> LabelPairs
-traceLabel t = [("trace_id", t)]
-
-traceAndSpanLabels :: Text -> Text -> LabelPairs
-traceAndSpanLabels t s = [("trace_id", t), ("span_id", s)]

--- a/prometheus-client/src/Prometheus/Label.hs
+++ b/prometheus-client/src/Prometheus/Label.hs
@@ -14,6 +14,8 @@ module Prometheus.Label (
 ,   Label7
 ,   Label8
 ,   Label9
+,   traceLabel
+,   traceAndSpanLabels
 ) where
 
 import Data.Text
@@ -88,3 +90,9 @@ instance (a ~ Text, b ~ a, c ~ a, d ~ a, e ~ a, f ~ a, g ~ a, h ~ a, i ~ a) => L
                (v1, v2, v3, v4, v5, v6, v7, v8, v9) =
             [(k1, v1), (k2, v2), (k3, v3), (k4, v4), (k5, v5), (k6, v6),
              (k7, v7), (k8, v8), (k9, v9)]
+
+traceLabel :: Text -> LabelPairs
+traceLabel t = [("trace_id", t)]
+
+traceAndSpanLabels :: Text -> Text -> LabelPairs
+traceAndSpanLabels t s = [("trace_id", t), ("span_id", s)]

--- a/prometheus-client/src/Prometheus/Metric.hs
+++ b/prometheus-client/src/Prometheus/Metric.hs
@@ -32,9 +32,9 @@ instance Show SampleType where
     show UntypedType   = "untyped"
 
 -- | A single value recorded at a moment in time. The sample type contains the
--- name of the sample, a list of labels and their values, and the value encoded
--- as a ByteString.
-data Sample = Sample Text LabelPairs BS.ByteString
+-- name of the sample, a list of labels and their values, the value encoded
+-- as a ByteString, and an exemplar (histogram only).
+data Sample = Sample Text LabelPairs BS.ByteString LabelPairs
     deriving (Show)
 
 -- | A Sample group is a list of samples that is tagged with meta data

--- a/prometheus-client/src/Prometheus/Metric.hs
+++ b/prometheus-client/src/Prometheus/Metric.hs
@@ -5,6 +5,7 @@ module Prometheus.Metric (
 ,   Sample (..)
 ,   SampleGroup (..)
 ,   SampleType (..)
+,   SampleExemplar(..)
 ) where
 
 import Prometheus.Info
@@ -13,6 +14,7 @@ import Prometheus.Label
 import Control.DeepSeq
 import qualified Data.ByteString as BS
 import Data.Text (Text)
+import System.Clock
 
 
 -- | The type of a sample. This corresponds to the 5 types of metrics supported
@@ -31,10 +33,16 @@ instance Show SampleType where
     show HistogramType = "histogram"
     show UntypedType   = "untyped"
 
+-- | A specific example for a metric. Contains key-value pairs for the sample
+-- (e.g. a trace_id), the value of the sample encoded as a ByteString,
+-- and an optional timestamp.
+data SampleExemplar = SampleExemplar LabelPairs BS.ByteString (Maybe TimeSpec)
+    deriving (Show)
+
 -- | A single value recorded at a moment in time. The sample type contains the
 -- name of the sample, a list of labels and their values, the value encoded
--- as a ByteString, and an exemplar (histogram only).
-data Sample = Sample Text LabelPairs BS.ByteString LabelPairs
+-- as a ByteString, and an exemplar (counter and histogram only).
+data Sample = Sample Text LabelPairs BS.ByteString (Maybe SampleExemplar)
     deriving (Show)
 
 -- | A Sample group is a list of samples that is tagged with meta data

--- a/prometheus-client/src/Prometheus/Metric/Counter.hs
+++ b/prometheus-client/src/Prometheus/Metric/Counter.hs
@@ -77,7 +77,7 @@ getCounter (MkCounter ioref) = liftIO $ IORef.readIORef ioref
 collectCounter :: Info -> IORef.IORef Double -> IO [SampleGroup]
 collectCounter info c = do
     value <- IORef.readIORef c
-    let sample = Sample (metricName info) [] (BS.fromString $ show value) []
+    let sample = Sample (metricName info) [] (BS.fromString $ show value) Nothing
     return [SampleGroup info CounterType [sample]]
 
 -- | Count the amount of times an action throws any synchronous exception.

--- a/prometheus-client/src/Prometheus/Metric/Counter.hs
+++ b/prometheus-client/src/Prometheus/Metric/Counter.hs
@@ -77,7 +77,7 @@ getCounter (MkCounter ioref) = liftIO $ IORef.readIORef ioref
 collectCounter :: Info -> IORef.IORef Double -> IO [SampleGroup]
 collectCounter info c = do
     value <- IORef.readIORef c
-    let sample = Sample (metricName info) [] (BS.fromString $ show value)
+    let sample = Sample (metricName info) [] (BS.fromString $ show value) []
     return [SampleGroup info CounterType [sample]]
 
 -- | Count the amount of times an action throws any synchronous exception.

--- a/prometheus-client/src/Prometheus/Metric/Gauge.hs
+++ b/prometheus-client/src/Prometheus/Metric/Gauge.hs
@@ -77,5 +77,5 @@ setGaugeToDuration metric io = do
 collectGauge :: Info -> IORef.IORef Double -> IO [SampleGroup]
 collectGauge info c = do
     value <- IORef.readIORef c
-    let sample = Sample (metricName info) [] (BS.fromString $ show value) []
+    let sample = Sample (metricName info) [] (BS.fromString $ show value) Nothing
     return [SampleGroup info GaugeType [sample]]

--- a/prometheus-client/src/Prometheus/Metric/Gauge.hs
+++ b/prometheus-client/src/Prometheus/Metric/Gauge.hs
@@ -77,5 +77,5 @@ setGaugeToDuration metric io = do
 collectGauge :: Info -> IORef.IORef Double -> IO [SampleGroup]
 collectGauge info c = do
     value <- IORef.readIORef c
-    let sample = Sample (metricName info) [] (BS.fromString $ show value)
+    let sample = Sample (metricName info) [] (BS.fromString $ show value) []
     return [SampleGroup info GaugeType [sample]]

--- a/prometheus-client/src/Prometheus/Metric/Histogram.hs
+++ b/prometheus-client/src/Prometheus/Metric/Histogram.hs
@@ -1,5 +1,6 @@
 {-# language BangPatterns #-}
 {-# language OverloadedStrings #-}
+{-# language RecordWildCards #-}
 
 module Prometheus.Metric.Histogram (
     Histogram
@@ -34,6 +35,7 @@ import Data.Monoid ((<>))
 import Data.Text (Text)
 import qualified Data.Text as T
 import Numeric (showFFloat)
+import System.Clock
 
 -- | A histogram. Counts the number of observations that fall within the
 -- specified buckets.
@@ -54,6 +56,12 @@ histogram info buckets = Metric $ do
 -- | Upper-bound for a histogram bucket.
 type Bucket = Double
 
+data HistogramExemplar = HistogramExemplar {
+    histExemplarLabelPairs :: LabelPairs
+,   histExemplarValue :: !Double
+,   histExemplarTimestamp :: !(Maybe TimeSpec)
+} deriving (Show, Eq, Ord)
+
 -- | Current state of a histogram.
 data BucketCounts = BucketCounts {
     -- | The sum of all the observations.
@@ -64,12 +72,12 @@ data BucketCounts = BucketCounts {
     -- value is the number of observations less-than-or-equal-to
     -- that upper bound, but greater than the next lowest upper bound.
 ,   histCountsPerBucket :: !(Map.Map Bucket Int)
-,   histBucketLabels :: !(Map.Map Bucket LabelPairs)
+,   histBucketExemplars :: !(Map.Map Bucket (Maybe HistogramExemplar))
 } deriving (Show, Eq, Ord)
 
 emptyCounts :: [Bucket] -> BucketCounts
 emptyCounts buckets
-    | isStrictlyIncreasing buckets = BucketCounts 0 0 (Map.fromList (zip buckets (repeat 0))) (Map.fromList (zip buckets (repeat [])))
+    | isStrictlyIncreasing buckets = BucketCounts 0 0 (Map.fromList (zip buckets (repeat 0))) (Map.fromList (zip buckets (repeat Nothing)))
     | otherwise = error ("Histogram buckets must be in increasing order, got: " ++ show buckets)
     where
          isStrictlyIncreasing xs = and (zipWith (<) xs (tail xs))
@@ -89,8 +97,8 @@ instance Observer Histogram where
 -- This feature is experimental and must be [enabled on the Prometheus server](https://prometheus.io/docs/prometheus/latest/feature_flags/).
 --
 -- > withLabel incomingHttpRequestSeconds "Signup_POST" (`observeWithExemplar` 1.23 [("trace_id", "12345"), ("span_id", "67890")])
-observeWithExemplar :: Histogram -> Double -> LabelPairs -> IO ()
-observeWithExemplar h v lp = withHistogram h (insertWithExemplar v lp)
+observeWithExemplar :: Histogram -> Double -> HistogramExemplar -> IO ()
+observeWithExemplar h v exemplar = withHistogram h (insertWithExemplar v (Just exemplar))
 
 -- | Transform the contents of a histogram.
 withHistogram :: MonadMonitor m
@@ -107,36 +115,36 @@ getHistogram (MkHistogram bucketsTVar) =
 
 -- | Record an observation.
 insert :: Double -> BucketCounts -> BucketCounts
-insert value bucketCounts = insertWithExemplar value [] bucketCounts 
+insert value bucketCounts = insertWithExemplar value Nothing bucketCounts 
 
-insertWithExemplar :: Double -> LabelPairs -> BucketCounts -> BucketCounts
-insertWithExemplar value newLabelPairs BucketCounts { histTotal = total, histCount = count, histCountsPerBucket = counts, histBucketLabels = existingLabelMap } =
+insertWithExemplar :: Double -> (Maybe HistogramExemplar) -> BucketCounts -> BucketCounts
+insertWithExemplar value mHistogramExemplar BucketCounts { histTotal = total, histCount = count, histCountsPerBucket = counts, histBucketExemplars = existingExemplarMap } =
     let updatedValues = case Map.lookupGE value counts of
                 Nothing -> counts
                 Just (upperBound, _) -> Map.adjust (+1) upperBound counts
 
-        updatedLabels = case newLabelPairs of 
-            [] -> existingLabelMap
-            _xs -> case Map.lookupGE value counts of
-                Nothing -> existingLabelMap
-                Just (upperBound, _) -> Map.insert upperBound newLabelPairs existingLabelMap
+        updatedLabels = case mHistogramExemplar of 
+            Nothing -> existingExemplarMap
+            Just newExemplar -> case Map.lookupGE value counts of
+                Nothing -> existingExemplarMap
+                Just (upperBound, _) -> Map.insert upperBound (Just newExemplar) existingExemplarMap
 
     in BucketCounts (total + value) (count + 1) updatedValues updatedLabels
 
 -- | Collect the current state of a histogram.
 collectHistogram :: Info -> STM.TVar BucketCounts -> IO [SampleGroup]
 collectHistogram info bucketCounts = STM.atomically $ do
-    BucketCounts total count counts labels <- STM.readTVar bucketCounts
-    let sumSample = Sample (name <> "_sum") [] (bsShow total) []
-    let countSample = Sample (name <> "_count") [] (bsShow count) []
-    let infSample = Sample (name <> "_bucket") [(bucketLabel, "+Inf")] (bsShow count) []
+    BucketCounts total count counts mHistExemplarMap <- STM.readTVar bucketCounts
+    let sumSample = Sample (name <> "_sum") [] (bsShow total) Nothing
+    let countSample = Sample (name <> "_count") [] (bsShow count) Nothing
+    let infSample = Sample (name <> "_bucket") [(bucketLabel, "+Inf")] (bsShow count) Nothing
     let upperBoundAndCount = cumulativeSum (Map.toAscList counts)
-        exemplarLabelPairs = map snd (Map.toAscList labels)
-        samples = map toSample (zip upperBoundAndCount exemplarLabelPairs)
+        mHistExemplars = map snd (Map.toAscList mHistExemplarMap)
+        samples = map toSample (zip upperBoundAndCount mHistExemplars)
     return [SampleGroup info HistogramType $ samples ++ [infSample, sumSample, countSample]]
     where
-        toSample ((upperBound, count'), exemplarLabelPairs) =
-            Sample (name <> "_bucket") [(bucketLabel, formatFloat upperBound)] (bsShow count') exemplarLabelPairs
+        toSample ((upperBound, count'), mHistExemplar) =
+            Sample (name <> "_bucket") [(bucketLabel, formatFloat upperBound)] (bsShow count') (histExemlarToSampleExemplar <$> mHistExemplar)
         name = metricName info
 
         -- We don't particularly want scientific notation, so force regular
@@ -147,6 +155,10 @@ collectHistogram info bucketCounts = STM.atomically $ do
 
         bsShow :: Show s => s -> BS.ByteString
         bsShow = BS.fromString . show
+
+        histExemlarToSampleExemplar :: HistogramExemplar -> SampleExemplar
+        histExemlarToSampleExemplar HistogramExemplar{..} = 
+            SampleExemplar histExemplarLabelPairs (bsShow histExemplarValue) histExemplarTimestamp
 
 -- | The label that defines the upper bound of a bucket of a histogram. @"le"@
 -- is short for "less than or equal to".

--- a/prometheus-client/src/Prometheus/Metric/Histogram.hs
+++ b/prometheus-client/src/Prometheus/Metric/Histogram.hs
@@ -10,6 +10,7 @@ module Prometheus.Metric.Histogram (
 ,   exponentialBuckets
 ,   linearBuckets
 ,   observeWithExemplar
+,   ExemplarMetadata(..)
 
 -- * Exported for testing
 ,   BucketCounts(..)
@@ -56,6 +57,9 @@ histogram info buckets = Metric $ do
 -- | Upper-bound for a histogram bucket.
 type Bucket = Double
 
+data ExemplarMetadata = ExemplarMetadata LabelPairs !(Maybe TimeSpec)
+  deriving (Show)
+
 data HistogramExemplar = HistogramExemplar {
     histExemplarLabelPairs :: LabelPairs
 ,   histExemplarValue :: !Double
@@ -97,8 +101,8 @@ instance Observer Histogram where
 -- This feature is experimental and must be [enabled on the Prometheus server](https://prometheus.io/docs/prometheus/latest/feature_flags/).
 --
 -- > withLabel incomingHttpRequestSeconds "Signup_POST" (`observeWithExemplar` 1.23 [("trace_id", "12345"), ("span_id", "67890")])
-observeWithExemplar :: Histogram -> Double -> HistogramExemplar -> IO ()
-observeWithExemplar h v exemplar = withHistogram h (insertWithExemplar v (Just exemplar))
+observeWithExemplar :: Histogram -> Double -> ExemplarMetadata -> IO ()
+observeWithExemplar h v (ExemplarMetadata labelPairs mTimestamp) = withHistogram h (insertWithExemplar v (Just (HistogramExemplar labelPairs v mTimestamp)))
 
 -- | Transform the contents of a histogram.
 withHistogram :: MonadMonitor m

--- a/prometheus-client/src/Prometheus/Metric/Histogram.hs
+++ b/prometheus-client/src/Prometheus/Metric/Histogram.hs
@@ -88,6 +88,8 @@ instance Observer Histogram where
 -- Typically the values tracked are "trace_id" and "span_id".
 --
 -- This feature is experimental and must be [enabled on the Prometheus server](https://prometheus.io/docs/prometheus/latest/feature_flags/).
+--
+-- > withLabel incomingHttpRequestSeconds "Signup_POST" (`observeWithExemplar` 1.23 [("trace_id", "12345"), ("span_id", "67890")])
 observeWithExemplar :: Histogram -> Double -> LabelPairs -> IO ()
 observeWithExemplar h v lp = withHistogram h (insertWithExemplar v lp)
 
@@ -135,8 +137,8 @@ collectHistogram info bucketCounts = STM.atomically $ do
         samples = map toSample (zip upperBoundAndCount exemplarLabelPairs)
     return [SampleGroup info HistogramType $ samples ++ [infSample, sumSample, countSample]]
     where
-        toSample ((upperBound, count'), labelPairs) =
-            Sample (name <> "_bucket") [(bucketLabel, formatFloat upperBound)] (bsShow count') labelPairs
+        toSample ((upperBound, count'), exemplarLabelPairs) =
+            Sample (name <> "_bucket") [(bucketLabel, formatFloat upperBound)] (bsShow count') exemplarLabelPairs
         name = metricName info
 
         -- We don't particularly want scientific notation, so force regular

--- a/prometheus-client/src/Prometheus/Metric/Histogram.hs
+++ b/prometheus-client/src/Prometheus/Metric/Histogram.hs
@@ -130,7 +130,7 @@ collectHistogram info bucketCounts = STM.atomically $ do
     let sumSample = Sample (name <> "_sum") [] (bsShow total) []
     let countSample = Sample (name <> "_count") [] (bsShow count) []
     let infSample = Sample (name <> "_bucket") [(bucketLabel, "+Inf")] (bsShow count) []
-    let upperBoundAndCount = (cumulativeSum (Map.toAscList counts))
+    let upperBoundAndCount = cumulativeSum (Map.toAscList counts)
         exemplarLabelPairs = map snd (Map.toAscList labels)
         samples = map toSample (zip upperBoundAndCount exemplarLabelPairs)
     return [SampleGroup info HistogramType $ samples ++ [infSample, sumSample, countSample]]

--- a/prometheus-client/src/Prometheus/Metric/Histogram.hs
+++ b/prometheus-client/src/Prometheus/Metric/Histogram.hs
@@ -1,5 +1,6 @@
 {-# language BangPatterns #-}
 {-# language OverloadedStrings #-}
+{-# language ScopedTypeVariables #-}
 
 module Prometheus.Metric.Histogram (
     Histogram
@@ -8,15 +9,18 @@ module Prometheus.Metric.Histogram (
 ,   defaultBuckets
 ,   exponentialBuckets
 ,   linearBuckets
+,   observeWithExemplar
 
 -- * Exported for testing
 ,   BucketCounts(..)
 ,   insert
+,   insertWithExemplar
 ,   emptyCounts
 ,   getHistogram
 ) where
 
 import Prometheus.Info
+import Prometheus.Label
 import Prometheus.Metric
 import Prometheus.Metric.Observer
 import Prometheus.MonadMonitor
@@ -61,11 +65,12 @@ data BucketCounts = BucketCounts {
     -- value is the number of observations less-than-or-equal-to
     -- that upper bound, but greater than the next lowest upper bound.
 ,   histCountsPerBucket :: !(Map.Map Bucket Int)
+,   histBucketLabels :: !(Map.Map Bucket LabelPairs)
 } deriving (Show, Eq, Ord)
 
 emptyCounts :: [Bucket] -> BucketCounts
 emptyCounts buckets
-    | isStrictlyIncreasing buckets = BucketCounts 0 0 $ Map.fromList (zip buckets (repeat 0))
+    | isStrictlyIncreasing buckets = BucketCounts 0 0 (Map.fromList (zip buckets (repeat 0))) (Map.fromList (zip buckets (repeat [])))
     | otherwise = error ("Histogram buckets must be in increasing order, got: " ++ show buckets)
     where
          isStrictlyIncreasing xs = and (zipWith (<) xs (tail xs))
@@ -73,6 +78,18 @@ emptyCounts buckets
 instance Observer Histogram where
     -- | Add a new observation to a histogram metric.
     observe h v = withHistogram h (insert v)
+
+-- | Observe that a particular floating point value has occurred.
+-- For example, observe that this request took 0.23s.
+--
+-- In addition, tracks a set of key-value pairs called an [exemplar](https://grafana.com/docs/grafana/latest/fundamentals/exemplars/)
+-- which are used to correlate time series data with traces.
+--
+-- Typically the values tracked are "trace_id" and "span_id".
+--
+-- This feature is experimental and must be [enabled on the Prometheus server](https://prometheus.io/docs/prometheus/latest/feature_flags/).
+observeWithExemplar :: Histogram -> Double -> LabelPairs -> IO ()
+observeWithExemplar h v lp = withHistogram h (insertWithExemplar v lp)
 
 -- | Transform the contents of a histogram.
 withHistogram :: MonadMonitor m
@@ -87,28 +104,39 @@ getHistogram :: MonadIO m => Histogram -> m (Map.Map Bucket Int)
 getHistogram (MkHistogram bucketsTVar) =
     liftIO $ histCountsPerBucket <$> STM.atomically (STM.readTVar bucketsTVar)
 
+
 -- | Record an observation.
 insert :: Double -> BucketCounts -> BucketCounts
-insert value BucketCounts { histTotal = total, histCount = count, histCountsPerBucket = counts } =
-    BucketCounts (total + value) (count + 1) incCounts
-    where
-        incCounts =
-            case Map.lookupGE value counts of
+insert value bucketCounts = insertWithExemplar value [] bucketCounts 
+
+insertWithExemplar :: Double -> LabelPairs -> BucketCounts -> BucketCounts
+insertWithExemplar value newLabelPairs BucketCounts { histTotal = total, histCount = count, histCountsPerBucket = counts, histBucketLabels = existingLabelMap } =
+    let updatedValues = case Map.lookupGE value counts of
                 Nothing -> counts
                 Just (upperBound, _) -> Map.adjust (+1) upperBound counts
+
+        updatedLabels = case newLabelPairs of 
+            [] -> existingLabelMap
+            _xs -> case Map.lookupGE value counts of
+                Nothing -> existingLabelMap
+                Just (upperBound, _) -> Map.insert upperBound newLabelPairs existingLabelMap
+
+    in BucketCounts (total + value) (count + 1) updatedValues updatedLabels
 
 -- | Collect the current state of a histogram.
 collectHistogram :: Info -> STM.TVar BucketCounts -> IO [SampleGroup]
 collectHistogram info bucketCounts = STM.atomically $ do
-    BucketCounts total count counts <- STM.readTVar bucketCounts
-    let sumSample = Sample (name <> "_sum") [] (bsShow total)
-    let countSample = Sample (name <> "_count") [] (bsShow count)
-    let infSample = Sample (name <> "_bucket") [(bucketLabel, "+Inf")] (bsShow count)
-    let samples = map toSample (cumulativeSum (Map.toAscList counts))
+    BucketCounts total count counts labels <- STM.readTVar bucketCounts
+    let sumSample :: Sample = Sample (name <> "_sum") [] (bsShow total) []
+    let countSample = Sample (name <> "_count") [] (bsShow count) []
+    let infSample = Sample (name <> "_bucket") [(bucketLabel, "+Inf")] (bsShow count) []
+    let upperBoundAndCount = (cumulativeSum (Map.toAscList counts))
+        exemplarLabelPairs = map snd (Map.toAscList labels)
+        samples = map toSample (zip upperBoundAndCount exemplarLabelPairs)
     return [SampleGroup info HistogramType $ samples ++ [infSample, sumSample, countSample]]
     where
-        toSample (upperBound, count') =
-            Sample (name <> "_bucket") [(bucketLabel, formatFloat upperBound)] $ bsShow count'
+        toSample ((upperBound, count'), labelPairs) =
+            Sample (name <> "_bucket") [(bucketLabel, formatFloat upperBound)] (bsShow count') labelPairs
         name = metricName info
 
         -- We don't particularly want scientific notation, so force regular

--- a/prometheus-client/src/Prometheus/Metric/Histogram.hs
+++ b/prometheus-client/src/Prometheus/Metric/Histogram.hs
@@ -1,6 +1,5 @@
 {-# language BangPatterns #-}
 {-# language OverloadedStrings #-}
-{-# language ScopedTypeVariables #-}
 
 module Prometheus.Metric.Histogram (
     Histogram
@@ -106,7 +105,6 @@ getHistogram :: MonadIO m => Histogram -> m (Map.Map Bucket Int)
 getHistogram (MkHistogram bucketsTVar) =
     liftIO $ histCountsPerBucket <$> STM.atomically (STM.readTVar bucketsTVar)
 
-
 -- | Record an observation.
 insert :: Double -> BucketCounts -> BucketCounts
 insert value bucketCounts = insertWithExemplar value [] bucketCounts 
@@ -129,7 +127,7 @@ insertWithExemplar value newLabelPairs BucketCounts { histTotal = total, histCou
 collectHistogram :: Info -> STM.TVar BucketCounts -> IO [SampleGroup]
 collectHistogram info bucketCounts = STM.atomically $ do
     BucketCounts total count counts labels <- STM.readTVar bucketCounts
-    let sumSample :: Sample = Sample (name <> "_sum") [] (bsShow total) []
+    let sumSample = Sample (name <> "_sum") [] (bsShow total) []
     let countSample = Sample (name <> "_count") [] (bsShow count) []
     let infSample = Sample (name <> "_bucket") [(bucketLabel, "+Inf")] (bsShow count) []
     let upperBoundAndCount = (cumulativeSum (Map.toAscList counts))

--- a/prometheus-client/src/Prometheus/Metric/Summary.hs
+++ b/prometheus-client/src/Prometheus/Metric/Summary.hs
@@ -93,8 +93,8 @@ collectSummary info (MkSummary sketchVar quantiles_) = withMVar sketchVar $ \ske
     count_ <- ReqSketch.count sketch
     estimatedQuantileValues <- forM quantiles_ $ \qv ->
       (,) <$> pure (fst qv) <*> ReqSketch.quantile sketch (toDouble $ fst qv)
-    let sumSample = Sample (metricName info <> "_sum") [] (bsShow itemSum)
-    let countSample = Sample (metricName info <> "_count") [] (bsShow count_)
+    let sumSample = Sample (metricName info <> "_sum") [] (bsShow itemSum) []
+    let countSample = Sample (metricName info <> "_count") [] (bsShow count_) []
     return [SampleGroup info SummaryType $ map toSample estimatedQuantileValues ++ [sumSample, countSample]]
     where
         bsShow :: Show s => s -> BS.ByteString
@@ -102,8 +102,8 @@ collectSummary info (MkSummary sketchVar quantiles_) = withMVar sketchVar $ \ske
 
         toSample :: (Rational, Double) -> Sample
         toSample (q, estimatedValue) =
-            Sample (metricName info) [("quantile", T.pack . show $ toDouble q)] $
-                bsShow estimatedValue
+            Sample (metricName info) [("quantile", T.pack . show $ toDouble q)] 
+                (bsShow estimatedValue) []
 
         toDouble :: Rational -> Double
         toDouble = fromRational

--- a/prometheus-client/src/Prometheus/Metric/Summary.hs
+++ b/prometheus-client/src/Prometheus/Metric/Summary.hs
@@ -93,8 +93,8 @@ collectSummary info (MkSummary sketchVar quantiles_) = withMVar sketchVar $ \ske
     count_ <- ReqSketch.count sketch
     estimatedQuantileValues <- forM quantiles_ $ \qv ->
       (,) <$> pure (fst qv) <*> ReqSketch.quantile sketch (toDouble $ fst qv)
-    let sumSample = Sample (metricName info <> "_sum") [] (bsShow itemSum) []
-    let countSample = Sample (metricName info <> "_count") [] (bsShow count_) []
+    let sumSample = Sample (metricName info <> "_sum") [] (bsShow itemSum) Nothing
+    let countSample = Sample (metricName info <> "_count") [] (bsShow count_) Nothing
     return [SampleGroup info SummaryType $ map toSample estimatedQuantileValues ++ [sumSample, countSample]]
     where
         bsShow :: Show s => s -> BS.ByteString
@@ -103,7 +103,7 @@ collectSummary info (MkSummary sketchVar quantiles_) = withMVar sketchVar $ \ske
         toSample :: (Rational, Double) -> Sample
         toSample (q, estimatedValue) =
             Sample (metricName info) [("quantile", T.pack . show $ toDouble q)] 
-                (bsShow estimatedValue) []
+                (bsShow estimatedValue) Nothing
 
         toDouble :: Rational -> Double
         toDouble = fromRational

--- a/prometheus-client/src/Prometheus/Metric/Vector.hs
+++ b/prometheus-client/src/Prometheus/Metric/Vector.hs
@@ -67,8 +67,8 @@ collectVector keys ioref = do
         adjustSamples labels (SampleGroup info ty samples) =
             SampleGroup info ty (map (prependLabels labels) samples)
 
-        prependLabels l (Sample name labels value) =
-            Sample name (labelPairs keys l ++ labels) value
+        prependLabels l (Sample name labels value exemplarLabelPairs) =
+            Sample name (labelPairs keys l ++ labels) value exemplarLabelPairs
 
         joinSamples []                      = []
         joinSamples s@(SampleGroup i t _:_) = [SampleGroup i t (extract s)]

--- a/prometheus-client/tests/Prometheus/Export/TextSpec.hs
+++ b/prometheus-client/tests/Prometheus/Export/TextSpec.hs
@@ -70,6 +70,30 @@ spec = before_ unregisterAll $ after_ unregisterAll $
                 ,   "metric_sum 3.0"
                 ,   "metric_count 3"
                 ])
+      it "renders histograms with exemplars" $ do
+            m <- register $ histogram (Info "metric" "help") defaultBuckets
+            observeWithExemplar m 1.0 [("trace_id", "1")]
+            observe m 1.0
+            observe m 1.0
+            result <- exportMetricsAsText
+            result `shouldBe` LT.encodeUtf8 (LT.pack $ unlines [
+                    "# HELP metric help"
+                ,   "# TYPE metric histogram"
+                ,   "metric_bucket{le=\"0.005\"} 0"
+                ,   "metric_bucket{le=\"0.01\"} 0"
+                ,   "metric_bucket{le=\"0.025\"} 0"
+                ,   "metric_bucket{le=\"0.05\"} 0"
+                ,   "metric_bucket{le=\"0.1\"} 0"
+                ,   "metric_bucket{le=\"0.25\"} 0"
+                ,   "metric_bucket{le=\"0.5\"} 0"
+                ,   "metric_bucket{le=\"1.0\"} 3 # {trace_id=\"1\"}"
+                ,   "metric_bucket{le=\"2.5\"} 3"
+                ,   "metric_bucket{le=\"5.0\"} 3"
+                ,   "metric_bucket{le=\"10.0\"} 3"
+                ,   "metric_bucket{le=\"+Inf\"} 3"
+                ,   "metric_sum 3.0"
+                ,   "metric_count 3"
+                ])
       it "renders vectors" $ do
             m <- register $ vector ("handler", "method")
                           $ counter (Info "test_counter" "help string")

--- a/prometheus-client/tests/Prometheus/Export/TextSpec.hs
+++ b/prometheus-client/tests/Prometheus/Export/TextSpec.hs
@@ -73,7 +73,7 @@ spec = before_ unregisterAll $ after_ unregisterAll $
       it "renders histograms with exemplars" $ do
             m <- register $ histogram (Info "metric" "help") defaultBuckets
             observeWithExemplar m 1.0 [("trace_id", "1")]
-            observe m 1.0
+            observeWithExemplar m 1.0 [("trace_id", "2")]
             observe m 1.0
             result <- exportMetricsAsText
             result `shouldBe` LT.encodeUtf8 (LT.pack $ unlines [
@@ -86,7 +86,7 @@ spec = before_ unregisterAll $ after_ unregisterAll $
                 ,   "metric_bucket{le=\"0.1\"} 0"
                 ,   "metric_bucket{le=\"0.25\"} 0"
                 ,   "metric_bucket{le=\"0.5\"} 0"
-                ,   "metric_bucket{le=\"1.0\"} 3 # {trace_id=\"1\"}"
+                ,   "metric_bucket{le=\"1.0\"} 3 # {trace_id=\"2\"}"
                 ,   "metric_bucket{le=\"2.5\"} 3"
                 ,   "metric_bucket{le=\"5.0\"} 3"
                 ,   "metric_bucket{le=\"10.0\"} 3"

--- a/prometheus-metrics-ghc/src/Prometheus/Metric/GHC.hs
+++ b/prometheus-metrics-ghc/src/Prometheus/Metric/GHC.hs
@@ -350,4 +350,4 @@ showCollector :: Show a => Text -> Text -> SampleType -> a -> LabelPairs -> IO [
 showCollector name help sampleType value labels = do
     let info = Info name help
     let valueBS = BS.fromString $ show value
-    return [SampleGroup info sampleType [Sample name labels valueBS []]]
+    return [SampleGroup info sampleType [Sample name labels valueBS Nothing]]

--- a/prometheus-metrics-ghc/src/Prometheus/Metric/GHC.hs
+++ b/prometheus-metrics-ghc/src/Prometheus/Metric/GHC.hs
@@ -350,4 +350,4 @@ showCollector :: Show a => Text -> Text -> SampleType -> a -> LabelPairs -> IO [
 showCollector name help sampleType value labels = do
     let info = Info name help
     let valueBS = BS.fromString $ show value
-    return [SampleGroup info sampleType [Sample name labels valueBS]]
+    return [SampleGroup info sampleType [Sample name labels valueBS []]]

--- a/prometheus-proc/src/Prometheus/Metric/Proc.hs
+++ b/prometheus-proc/src/Prometheus/Metric/Proc.hs
@@ -172,6 +172,7 @@ metric metricName metricHelp metricType value =
         metricName
         []
         ( fromString ( show value ) )
+        []
     ]
 
 


### PR DESCRIPTION
(edit: currently testing this and looks like I didn't get the output correct, going to iterate some more and closing for now)

Prometheus has a neat feature called [exemplars](https://grafana.com/docs/grafana/latest/fundamentals/exemplars/):

> An exemplar is a specific trace representative of measurement taken in a given time interval. While metrics excel at giving you an aggregated view of your system, traces give you a fine grained view of a single request; exemplars are a way to link the two.

Exemplars are only available on histograms. On each bucket, you can store a single list of key-value pairs (typically `trace_id` and `span_id`). The prometheus server will scrape those and they can be displayed in tools like Grafana. That way, when you're investigating requests above 10 seconds or whatever, you can find examples to dig into in a tracing tool like Honeycomb. 

Exemplars considered experimental and must be [enabled on the prometheus server](https://prometheus.io/docs/prometheus/latest/feature_flags/). That said, this feature has existed for four years with support built into tools like Grafana already.

I haven't tested this against a running prometheus server yet, but thought I'd throw up the PR.

This PR would be a breaking change because it adds an argument to the `Sample` constructor. That said, I expect that most library users do not deal with samples directly.

--

This PR does add a couple of hlint warnings:

```
prometheus-client/src/Prometheus/Metric/Histogram.hs:110:1-68: Warning: Eta reduce
Found:
  insert value bucketCounts
    = insertWithExemplar value [] bucketCounts
Perhaps:
  insert value = insertWithExemplar value []

prometheus-client/src/Prometheus/Metric/Histogram.hs:135:19-74: Suggestion: Use zipWith
Found:
  map toSample (zip upperBoundAndCount exemplarLabelPairs)
Perhaps:
  zipWith (curry toSample) upperBoundAndCount exemplarLabelPairs```

But I didn't really like the suggested changes and I see there are plenty of other hlint warnings, so maybe lmk if it's fine to ignore those.